### PR TITLE
Fix/warnings

### DIFF
--- a/Compiler/Commons/Text/Position.cs
+++ b/Compiler/Commons/Text/Position.cs
@@ -1,27 +1,27 @@
 namespace KSPCompiler.Commons.Text
 {
-    // ReSharper disable UnusedAutoPropertyAccessor.Global
+    // ReSharper disable InconsistentNaming
     public struct Position
     {
         /// <summary>
         /// Starting line number.
         /// </summary>
-        public LineNumber BeginLine { get; init; }
+        public LineNumber BeginLine;
 
         /// <summary>
         /// End Line Number. It's -1 if it's unknown.
         /// </summary>
-        public LineNumber EndLine { get; init; }
+        public LineNumber EndLine;
 
         /// <summary>
         /// Start column number.
         /// </summary>
-        public Column BeginColumn { get; init; }
+        public Column BeginColumn;
 
         /// <summary>
         /// End Column Number. It's -1 if it's unknown.
         /// </summary>
-        public Column EndColumn { get; init; }
+        public Column EndColumn;
     }
-    // ReSharper restore UnusedAutoPropertyAccessor.Global
+    // ReSharper restore InconsistentNaming
 }

--- a/Compiler/Commons/Text/Position.cs
+++ b/Compiler/Commons/Text/Position.cs
@@ -1,25 +1,27 @@
 namespace KSPCompiler.Commons.Text
 {
+    // ReSharper disable UnusedAutoPropertyAccessor.Global
     public struct Position
     {
         /// <summary>
         /// Starting line number.
         /// </summary>
-        public LineNumber BeginLine;
+        public LineNumber BeginLine { get; init; }
 
         /// <summary>
         /// End Line Number. It's -1 if it's unknown.
         /// </summary>
-        public LineNumber EndLine;
+        public LineNumber EndLine { get; init; }
 
         /// <summary>
         /// Start column number.
         /// </summary>
-        public Column BeginColumn;
+        public Column BeginColumn { get; init; }
 
         /// <summary>
         /// End Column Number. It's -1 if it's unknown.
         /// </summary>
-        public Column EndColumn;
+        public Column EndColumn { get; init; }
     }
+    // ReSharper restore UnusedAutoPropertyAccessor.Global
 }

--- a/Compiler/Domain/Ast/Node/AstExpressionSyntaxNode.cs
+++ b/Compiler/Domain/Ast/Node/AstExpressionSyntaxNode.cs
@@ -1,6 +1,5 @@
 ﻿using System.IO;
 
-using KSPCompiler.Domain.Symbols;
 using KSPCompiler.Domain.Symbols.MetaData;
 
 namespace KSPCompiler.Domain.Ast.Node

--- a/Compiler/Domain/Ast/Node/Expressions/AstIntLiteral.cs
+++ b/Compiler/Domain/Ast/Node/Expressions/AstIntLiteral.cs
@@ -1,4 +1,3 @@
-using KSPCompiler.Domain.Symbols;
 using KSPCompiler.Domain.Symbols.MetaData;
 
 namespace KSPCompiler.Domain.Ast.Node.Expressions

--- a/Compiler/Domain/Ast/Node/Expressions/AstRealLiteral.cs
+++ b/Compiler/Domain/Ast/Node/Expressions/AstRealLiteral.cs
@@ -1,4 +1,3 @@
-using KSPCompiler.Domain.Symbols;
 using KSPCompiler.Domain.Symbols.MetaData;
 
 namespace KSPCompiler.Domain.Ast.Node.Expressions

--- a/Compiler/Domain/Ast/Node/Expressions/AstStringLiteral.cs
+++ b/Compiler/Domain/Ast/Node/Expressions/AstStringLiteral.cs
@@ -1,4 +1,3 @@
-using KSPCompiler.Domain.Symbols;
 using KSPCompiler.Domain.Symbols.MetaData;
 
 namespace KSPCompiler.Domain.Ast.Node.Expressions

--- a/Compiler/Domain/Ast/Node/IArgumentList.cs
+++ b/Compiler/Domain/Ast/Node/IArgumentList.cs
@@ -15,11 +15,11 @@ namespace KSPCompiler.Domain.Ast.Node
         /// <summary>
         /// Whether one or more arguments are stored in the ArgumentList or not.
         /// </summary>
-        public virtual bool HasArgument => ArgumentList is { HasArgument: true };
+        public bool HasArgument => ArgumentList is { HasArgument: true };
 
         /// <summary>
         /// Number of arguments stored in ArgumentList, 0 for null.
         /// </summary>
-        public virtual int ArgumentCount => HasArgument ? ArgumentList.Arguments.Count : 0;
+        public int ArgumentCount => HasArgument ? ArgumentList.Arguments.Count : 0;
     }
 }

--- a/Compiler/Domain/Ast/Node/IAstNode.cs
+++ b/Compiler/Domain/Ast/Node/IAstNode.cs
@@ -1,4 +1,3 @@
-using System;
 using System.IO;
 
 using KSPCompiler.Commons.Text;
@@ -17,7 +16,7 @@ namespace KSPCompiler.Domain.Ast.Node
         /// <summary>
         /// ID for identifying a node.
         /// </summary>
-        public virtual AstNodeId Id => AstNodeId.None;
+        public AstNodeId Id => AstNodeId.None;
 
         /// <summary>
         /// Token location information.

--- a/Compiler/Domain/CompilerMessages/ICompilerMessageManger.cs
+++ b/Compiler/Domain/CompilerMessages/ICompilerMessageManger.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -26,10 +25,10 @@ public interface ICompilerMessageManger
     #region Default
     private class DefaultMangerImpl : ICompilerMessageManger
     {
-        private readonly List<CompilerMessage> _messages = new(256);
+        private readonly List<CompilerMessage> messages = new(256);
 
         public IReadOnlyCollection<CompilerMessage> Messages
-            => new List<CompilerMessage>( _messages );
+            => new List<CompilerMessage>( messages );
 
         public ICompilerMessageFactory MessageFactory
             => ICompilerMessageFactory.Default;
@@ -41,7 +40,7 @@ public interface ICompilerMessageManger
 
         public void Append( CompilerMessage message )
         {
-            _messages.Add( message );
+            messages.Add( message );
 
             foreach( var x in Handlers )
             {
@@ -74,13 +73,13 @@ public interface ICompilerMessageManger
         }
 
         public int Count()
-            => _messages.Count;
+            => messages.Count;
 
         public int Count( CompilerMessageLevel level )
-            => _messages.Count( x => x.Level == level );
+            => messages.Count( x => x.Level == level );
 
         public bool IsEmpty()
-            => _messages.Count == 0;
+            => messages.Count == 0;
     }
     #endregion
 }

--- a/Compiler/Domain/Symbols/CommandSymbolTable.cs
+++ b/Compiler/Domain/Symbols/CommandSymbolTable.cs
@@ -1,9 +1,11 @@
+using System;
+
 namespace KSPCompiler.Domain.Symbols;
 
 public class CommandSymbolTable : SymbolTable<CommandSymbol>
 {
     public override bool Add( SymbolName name, CommandSymbol symbol )
     {
-        throw new System.NotImplementedException();
+        throw new NotImplementedException();
     }
 }

--- a/Compiler/Domain/Symbols/ISymbolTable.cs
+++ b/Compiler/Domain/Symbols/ISymbolTable.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using System.IO;
 

--- a/Compiler/Domain/Symbols/UITypeSymbolTable.cs
+++ b/Compiler/Domain/Symbols/UITypeSymbolTable.cs
@@ -1,9 +1,11 @@
+using System;
+
 namespace KSPCompiler.Domain.Symbols;
 
 public class UITypeSymbolTable : SymbolTable<UITypeSymbol>
 {
     public override bool Add( SymbolName name, UITypeSymbol symbol )
     {
-        throw new System.NotImplementedException();
+        throw new NotImplementedException();
     }
 }

--- a/Compiler/Domain/Symbols/UserFunctionSymbolTable.cs
+++ b/Compiler/Domain/Symbols/UserFunctionSymbolTable.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace KSPCompiler.Domain.Symbols;
 
 public class UserFunctionSymbolTable : SymbolTable<UserFunctionSymbol>
@@ -17,6 +19,6 @@ public class UserFunctionSymbolTable : SymbolTable<UserFunctionSymbol>
 
     public override bool Add( SymbolName name, UserFunctionSymbol symbol )
     {
-        throw new System.NotImplementedException();
+        throw new NotImplementedException();
     }
 }

--- a/Compiler/Domain/Symbols/VariableSymbol.cs
+++ b/Compiler/Domain/Symbols/VariableSymbol.cs
@@ -37,9 +37,6 @@ public sealed class VariableSymbol : SymbolBase
     public bool ConstantValueWithSingleOperator { get; set; } = false;
     #endregion ~ Properties
 
-    #region ctor
-    public VariableSymbol() {}
-    #endregion
 
     // TODO Implementation
 }

--- a/Compiler/Domain/Symbols/VariableSymbolTable.cs
+++ b/Compiler/Domain/Symbols/VariableSymbolTable.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace KSPCompiler.Domain.Symbols;
 
 public class VariableSymbolTable : SymbolTable<VariableSymbol>
@@ -17,6 +19,6 @@ public class VariableSymbolTable : SymbolTable<VariableSymbol>
 
     public override bool Add( SymbolName name, VariableSymbol symbol )
     {
-        throw new System.NotImplementedException();
+        throw new NotImplementedException();
     }
 }

--- a/Compiler/Infrastructures/Parser.Antlr.Tests/AstTranslatorTest.cs
+++ b/Compiler/Infrastructures/Parser.Antlr.Tests/AstTranslatorTest.cs
@@ -13,14 +13,14 @@ namespace KSPCompiler.Parser.Antlr.Tests;
 [TestFixture]
 public class AstTranslatorTest
 {
-    private static readonly string testDataDirectory = Path.Combine( "TestData", "AstTranslatorTest" );
+    private static readonly string TestDataDirectory = Path.Combine( "TestData", "AstTranslatorTest" );
 
     // ReSharper disable once UnusedMethodReturnValue.Local
     private static AstCompilationUnit TranslateImpl( string scriptFilePath )
     {
         var path = Path.Combine(
             TestContext.CurrentContext.TestDirectory,
-            testDataDirectory,
+            TestDataDirectory,
             scriptFilePath
         );
 

--- a/Compiler/Infrastructures/Parser.Antlr/KspFileSyntaxAnalyser.cs
+++ b/Compiler/Infrastructures/Parser.Antlr/KspFileSyntaxAnalyser.cs
@@ -7,7 +7,8 @@ namespace KSPCompiler.Infrastructures.Parser.Antlr;
 
 public class KspFileSyntaxAnalyser : KspSyntaxAnalyser
 {
-    public KspFileSyntaxAnalyser( string path, ICompilerMessageManger messageManger, Encoding encoding )
+    // ReSharper disable once UnusedParameter.Local
+    public KspFileSyntaxAnalyser( string path, ICompilerMessageManger messageManger, Encoding _ )
         : base( File.OpenRead( path ), messageManger )
     {}
 }

--- a/Compiler/Infrastructures/Parser.Antlr/KspSyntaxAnalyser.cs
+++ b/Compiler/Infrastructures/Parser.Antlr/KspSyntaxAnalyser.cs
@@ -66,7 +66,7 @@ public abstract class KspSyntaxAnalyser : ISyntaxAnalyser
             throw new KspScriptParseException( $"Syntax Invalid : {cst.exception}" );
         }
 
-        var ast = cst.Accept( new CSTConverterVisitor() ) as AstCompilationUnit;
+        var ast = cst.Accept( new CstConverterVisitor() ) as AstCompilationUnit;
         Debug.Assert( ast != null );
 
         return ast;

--- a/Compiler/Infrastructures/Parser.Antlr/Translators/CSTConverterVisitor_Expression.cs
+++ b/Compiler/Infrastructures/Parser.Antlr/Translators/CSTConverterVisitor_Expression.cs
@@ -10,7 +10,7 @@ using KSPCompiler.Infrastructures.Parser.Antlr.Translators.Extensions;
 namespace KSPCompiler.Infrastructures.Parser.Antlr.Translators
 {
     // Expression node generation implementation
-    public partial class CSTConverterVisitor
+    public partial class CstConverterVisitor
     {
         private TNode SetupExpressionNode<TNode>( TNode dest )
             where TNode : AstExpressionSyntaxNode

--- a/Compiler/Infrastructures/Parser.Antlr/Translators/CstConverterVisitor.cs
+++ b/Compiler/Infrastructures/Parser.Antlr/Translators/CstConverterVisitor.cs
@@ -13,7 +13,7 @@ namespace KSPCompiler.Infrastructures.Parser.Antlr.Translators
     /// <summary>
     /// Implementation of AST generation process based on CST.
     /// </summary>
-    public partial class CSTConverterVisitor : KSPParserBaseVisitor<AstNode>
+    public partial class CstConverterVisitor : KSPParserBaseVisitor<AstNode>
     {
         private void SetupChildNode(
             IAstNode? parent,

--- a/Compiler/Infrastructures/Parser.Antlr/Translators/CstConverterVisitor_Block.cs
+++ b/Compiler/Infrastructures/Parser.Antlr/Translators/CstConverterVisitor_Block.cs
@@ -10,7 +10,7 @@ using KSPCompiler.Infrastructures.Parser.Antlr.Translators.Extensions;
 namespace KSPCompiler.Infrastructures.Parser.Antlr.Translators
 {
     // Implementation of root, callback and user-defined function node generation
-    public partial class CSTConverterVisitor
+    public partial class CstConverterVisitor
     {
         public override AstNode VisitCompilationUnit( KSPParser.CompilationUnitContext context )
         {

--- a/Compiler/Infrastructures/Parser.Antlr/Translators/CstConverterVisitor_Expression_BInary.cs
+++ b/Compiler/Infrastructures/Parser.Antlr/Translators/CstConverterVisitor_Expression_BInary.cs
@@ -8,7 +8,7 @@ using KSPCompiler.Domain.Ast.Node.Expressions;
 namespace KSPCompiler.Infrastructures.Parser.Antlr.Translators
 {
     // implementation of binary operator node generation
-    public partial class CSTConverterVisitor
+    public partial class CstConverterVisitor
     {
         private AstNode VisitBinaryExpressionNodeImpl<TNode>(
             ParserRuleContext context,

--- a/Compiler/Infrastructures/Parser.Antlr/Translators/CstConverterVisitor_Expression_Unary.cs
+++ b/Compiler/Infrastructures/Parser.Antlr/Translators/CstConverterVisitor_Expression_Unary.cs
@@ -9,7 +9,7 @@ using KSPCompiler.Infrastructures.Parser.Antlr.Translators.Extensions;
 namespace KSPCompiler.Infrastructures.Parser.Antlr.Translators
 {
     // implementation of the unary operator node
-    public partial class CSTConverterVisitor
+    public partial class CstConverterVisitor
     {
         private TNode SetupUnaryOperatorNode<TNode>( TNode dest )
             where TNode : AstExpressionSyntaxNode

--- a/Compiler/Infrastructures/Parser.Antlr/Translators/CstConverterVisitor_KspPreprocessor.cs
+++ b/Compiler/Infrastructures/Parser.Antlr/Translators/CstConverterVisitor_KspPreprocessor.cs
@@ -8,7 +8,7 @@ using KSPCompiler.Infrastructures.Parser.Antlr.Translators.Extensions;
 namespace KSPCompiler.Infrastructures.Parser.Antlr.Translators
 {
     // implementation of the statement node
-    public partial class CSTConverterVisitor
+    public partial class CstConverterVisitor
     {
         public override AstNode VisitKspPreprocessorDefine( KSPParser.KspPreprocessorDefineContext context )
         {

--- a/Compiler/Infrastructures/Parser.Antlr/Translators/CstConverterVisitor_Statement.cs
+++ b/Compiler/Infrastructures/Parser.Antlr/Translators/CstConverterVisitor_Statement.cs
@@ -10,7 +10,7 @@ using KSPCompiler.Infrastructures.Parser.Antlr.Translators.Extensions;
 namespace KSPCompiler.Infrastructures.Parser.Antlr.Translators
 {
     // implementation of the statement node
-    public partial class CSTConverterVisitor
+    public partial class CstConverterVisitor
     {
         private TNode VisitControlStatementImpl<TNode>(
             ParserRuleContext condition,

--- a/Compiler/Infrastructures/Parser.Antlr/Translators/CstConverterVisitor_Util.cs
+++ b/Compiler/Infrastructures/Parser.Antlr/Translators/CstConverterVisitor_Util.cs
@@ -6,7 +6,7 @@ using KSPCompiler.Commons.Text;
 
 namespace KSPCompiler.Infrastructures.Parser.Antlr.Translators
 {
-    public partial class CSTConverterVisitor
+    public partial class CstConverterVisitor
     {
         #region TokenPosition
         private static Position ToPosition( ParserRuleContext context )

--- a/Compiler/Infrastructures/Parser.Antlr/Translators/CstConverterVisitor_VariableDeclaration.cs
+++ b/Compiler/Infrastructures/Parser.Antlr/Translators/CstConverterVisitor_VariableDeclaration.cs
@@ -8,7 +8,7 @@ using KSPCompiler.Infrastructures.Parser.Antlr.Translators.Extensions;
 namespace KSPCompiler.Infrastructures.Parser.Antlr.Translators
 {
     // implementation of the variable declaration node
-    public partial class CSTConverterVisitor
+    public partial class CstConverterVisitor
     {
         public override AstNode VisitVariableDeclaration( KSPParser.VariableDeclarationContext context )
         {


### PR DESCRIPTION
コンパイラ、Rider による警告箇所の解消。

- 未使用 using の削除
- 命名規則への準拠
  - CST -> Cst
  - _messages -> messages

----

Eliminated compiler and Rider warnings.

- Remove unused using.
- Conform to naming conventions
  - CST -> Cst
  - _messages -> messages