### PR TITLE
コンパイルエラー CS8427  対策でインナークラスをやめて internal クラスにした

### DIFF
--- a/Compiler/Domain/Symbols/ISymbolExporter.cs
+++ b/Compiler/Domain/Symbols/ISymbolExporter.cs
@@ -9,7 +9,7 @@ public interface ISymbolExporter<in TSymbol> where TSymbol : SymbolBase
     /// <summary>
     /// Null Object. Symbols export to nowhere.
     /// </summary>
-    public static ISymbolExporter<TSymbol> Null { get; } = new NullExporter();
+    public static ISymbolExporter<TSymbol> Null { get; } = new NullSymbolExporter<TSymbol>();
 
     /// <summary>
     /// Export symbol table to repository.
@@ -21,10 +21,14 @@ public interface ISymbolExporter<in TSymbol> where TSymbol : SymbolBase
     /// Export symbol table to repository.
     /// </summary>
     Task ExportAsync( IEnumerable<TSymbol> store, CancellationToken cancellationToken = default );
+}
 
-    private sealed class NullExporter : ISymbolExporter<TSymbol>
-    {
-        public async Task ExportAsync( IEnumerable<TSymbol> store, CancellationToken cancellationToken = default )
-            => await Task.CompletedTask;
-    }
+/// <summary>
+/// Do nothing exporter for Null Object.
+/// </summary>
+/// <typeparam name="TSymbol"></typeparam>
+internal sealed class NullSymbolExporter<TSymbol> : ISymbolExporter<TSymbol> where TSymbol : SymbolBase
+{
+    public async Task ExportAsync( IEnumerable<TSymbol> store, CancellationToken cancellationToken = default )
+        => await Task.CompletedTask;
 }

--- a/Compiler/Domain/Symbols/ISymbolImporter.cs
+++ b/Compiler/Domain/Symbols/ISymbolImporter.cs
@@ -9,7 +9,7 @@ public interface ISymbolImporter<TSymbol> where TSymbol : SymbolBase
     /// <summary>
     /// Null Object. Always return empty symbol table.
     /// </summary>
-    public static ISymbolImporter<TSymbol> Null { get; } = new NullImporter();
+    public static ISymbolImporter<TSymbol> Null { get; } = new NullSymbolImporter<TSymbol>();
 
     /// <summary>
     /// Import symbol table from repository.
@@ -24,14 +24,17 @@ public interface ISymbolImporter<TSymbol> where TSymbol : SymbolBase
     /// Import symbol table from repository asynchronously.
     /// </summary>
     Task<IReadOnlyCollection<TSymbol>> ImportAsync( CancellationToken cancellationToken = default );
+}
 
-    private class NullImporter : ISymbolImporter<TSymbol>
+/// <summary>
+/// Do nothing importer for Null Object.
+/// </summary>
+internal class NullSymbolImporter<TSymbol> : ISymbolImporter<TSymbol> where TSymbol : SymbolBase
+{
+    public async Task<IReadOnlyCollection<TSymbol>> ImportAsync( CancellationToken cancellationToken = default )
     {
-        public async Task<IReadOnlyCollection<TSymbol>> ImportAsync( CancellationToken cancellationToken = default )
-        {
-            await Task.CompletedTask;
+        await Task.CompletedTask;
 
-            return new List<TSymbol>();
-        }
+        return new List<TSymbol>();
     }
 }


### PR DESCRIPTION
コンパイルエラー CS8427  対策でインナークラスをやめて internal クラスにした

Compile error CS8427: To prevent this, we stopped using an inner class and used an internal class.