### PR TITLE
Refactor/argument name

### DIFF
--- a/Compiler/Domain.Tests/MockSymbolTableUtility.cs
+++ b/Compiler/Domain.Tests/MockSymbolTableUtility.cs
@@ -35,7 +35,7 @@ public static class MockSymbolTableUtility
 
         example.AddArgument( new CommandArgumentSymbol
         {
-            Name = "text",
+            Name = "*text",
             DataType = DataTypeFlag.MultipleType,
             Description = "message text",
             Reserved = false,
@@ -59,7 +59,7 @@ public static class MockSymbolTableUtility
 
         example.AddInitializerArgument( new UIInitializerArgumentSymbol
         {
-            Name        = "width",
+            Name        = "$width",
             DataType    = DataTypeFlag.TypeInt,
             Description = "button width",
             Reserved    = false,

--- a/Compiler/Infrastructures/ExternalSymbolRepository.Tsv/Commands/Translators/ToTsvTranslator.cs
+++ b/Compiler/Infrastructures/ExternalSymbolRepository.Tsv/Commands/Translators/ToTsvTranslator.cs
@@ -30,7 +30,7 @@ internal class ToTsvTranslator : IDataTranslator<IEnumerable<CommandSymbol>, str
             result.AppendTab();
             foreach( var x in v.Arguments )
             {
-                result.AppendTab( DataTypeUtility.ToString( x.DataType ), x.Name )
+                result.AppendTab( x.Name )
                       .AppendTab( x.Description );
             }
 

--- a/Compiler/Infrastructures/ExternalSymbolRepository.Tsv/UITypes/Translators/FromTsvTranslator.cs
+++ b/Compiler/Infrastructures/ExternalSymbolRepository.Tsv/UITypes/Translators/FromTsvTranslator.cs
@@ -15,6 +15,7 @@ internal class FromTsvTranslator : IDataTranslator<string, IReadOnlyCollection<U
     {
         Name,
         Reserved,
+        VariableType,
         Description,
         RequireInitializer,
         InitializerArgumentBegin,
@@ -33,7 +34,7 @@ internal class FromTsvTranslator : IDataTranslator<string, IReadOnlyCollection<U
                     Name        = values[ (int)Column.Name ],
                     Reserved    = TsvUtility.ParseBoolean( values[ (int)Column.Reserved ] ),
                     Description = values[ (int)Column.Description ],
-                    DataType    = DataTypeUtility.Guess( values[ (int)Column.Name ] )
+                    DataType    = DataTypeUtility.Guess( values[ (int)Column.VariableType ] )
                 };
 
                 ParseInitializerArguments( values, uiType );

--- a/Compiler/Infrastructures/ExternalSymbolRepository.Tsv/UITypes/Translators/FromTsvTranslator.cs
+++ b/Compiler/Infrastructures/ExternalSymbolRepository.Tsv/UITypes/Translators/FromTsvTranslator.cs
@@ -15,7 +15,6 @@ internal class FromTsvTranslator : IDataTranslator<string, IReadOnlyCollection<U
     {
         Name,
         Reserved,
-        VariableType,
         Description,
         RequireInitializer,
         InitializerArgumentBegin,
@@ -34,7 +33,7 @@ internal class FromTsvTranslator : IDataTranslator<string, IReadOnlyCollection<U
                     Name        = values[ (int)Column.Name ],
                     Reserved    = TsvUtility.ParseBoolean( values[ (int)Column.Reserved ] ),
                     Description = values[ (int)Column.Description ],
-                    DataType    = DataTypeUtility.Guess( values[ (int)Column.VariableType ] )
+                    DataType    = DataTypeUtility.Guess( values[ (int)Column.Name ] )
                 };
 
                 ParseInitializerArguments( values, uiType );

--- a/Compiler/Infrastructures/ExternalSymbolRepository.Tsv/UITypes/Translators/ToTsvTranslator.cs
+++ b/Compiler/Infrastructures/ExternalSymbolRepository.Tsv/UITypes/Translators/ToTsvTranslator.cs
@@ -18,8 +18,8 @@ internal class ToTsvTranslator : IDataTranslator<IEnumerable<UITypeSymbol>, stri
         {
             result.AppendTab( v.Name )
                   .AppendTab( v.Reserved.ToString().ToLower() )
-                  .Append( DataTypeUtility.ToString( v.DataType ) )
-                  .AppendTab( v.Description );
+                  .AppendTab( DataTypeUtility.ToString( v.DataType ) )
+                  .Append( v.Description );
 
             if( v.InitializerArguments.Count == 0 )
             {

--- a/Compiler/Infrastructures/ExternalSymbolRepository.Tsv/UITypes/Translators/ToTsvTranslator.cs
+++ b/Compiler/Infrastructures/ExternalSymbolRepository.Tsv/UITypes/Translators/ToTsvTranslator.cs
@@ -18,8 +18,8 @@ internal class ToTsvTranslator : IDataTranslator<IEnumerable<UITypeSymbol>, stri
         {
             result.AppendTab( v.Name )
                   .AppendTab( v.Reserved.ToString().ToLower() )
-                  .AppendTab( v.Description )
-                  .Append( DataTypeUtility.ToString( v.DataType ) );
+                  .Append( DataTypeUtility.ToString( v.DataType ) )
+                  .AppendTab( v.Description );
 
             if( v.InitializerArguments.Count == 0 )
             {
@@ -32,7 +32,7 @@ internal class ToTsvTranslator : IDataTranslator<IEnumerable<UITypeSymbol>, stri
 
             foreach( var x in v.InitializerArguments )
             {
-                result.AppendTab( DataTypeUtility.ToString( x.DataType ), x.Name )
+                result.AppendTab( x.Name )
                       .AppendTab( x.Description );
             }
 


### PR DESCRIPTION
- Fixed a problem in which the first character of a variable name did not contain a symbol to identify the type
- UI Types: TSV column spec fixes