### PR TITLE
Create Visitor with non generic (T is IAstNode) version

### DIFF
--- a/Compiler/Domain/Ast/Nodes/DefaultAstVisitor.cs
+++ b/Compiler/Domain/Ast/Nodes/DefaultAstVisitor.cs
@@ -4,7 +4,7 @@ using KSPCompiler.Domain.Ast.Nodes.Statements;
 
 namespace KSPCompiler.Domain.Ast.Nodes;
 
-public abstract class DefaultAstVisitor : IAstVisitor<IAstNode>
+public abstract class DefaultAstVisitor : IAstVisitor
 {
     public virtual IAstNode VisitChildren( IAstNode node )
     {

--- a/Compiler/Domain/Ast/Nodes/IAstVisitor.cs
+++ b/Compiler/Domain/Ast/Nodes/IAstVisitor.cs
@@ -57,4 +57,9 @@ namespace KSPCompiler.Domain.Ast.Nodes
         public T Visit( AstPrimitiveInitializer node );
         public T Visit( AstArrayInitializer node );
     }
+
+    /// <summary>
+    /// Non-generic version of <see cref="IAstVisitor{T}"/>. <see cref="IAstNode" /> is used as the return type.
+    /// </summary>
+    public interface IAstVisitor : IAstVisitor<IAstNode> {}
 }


### PR DESCRIPTION
ほとんどのケースにおいて IAstNode 以外の型を使う局面が現状ないため、使用箇所で <T> を取り回すことが煩雑になる

In most cases, there is no aspect of using types other than IAstNode at the moment, so it is complicated to specify <T> at the point of use.