### PR TITLE
Rename class name

### DIFF
--- a/Compiler/Domain/Ast/Analyzers/Convolutions/IntegerBinaryOperatorConvolutionCalculator.cs
+++ b/Compiler/Domain/Ast/Analyzers/Convolutions/IntegerBinaryOperatorConvolutionCalculator.cs
@@ -5,13 +5,13 @@ using KSPCompiler.Domain.Ast.Nodes;
 namespace KSPCompiler.Domain.Ast.Analyzers.Convolutions;
 
 /// <summary>
-/// Calculator for convolution operations with binary operations
+/// Calculator for convolution operations with binary operators
 /// </summary>
-public sealed class IntegerConvolutionBinaryCalculator : IConvolutionBinaryCalculator<int>
+public sealed class IntegerBinaryOperatorConvolutionCalculator : IConvolutionBinaryCalculator<int>
 {
     private IConvolutionEvaluator<int> EvaluatorForRecursive { get; }
 
-    public IntegerConvolutionBinaryCalculator( IConvolutionEvaluator<int> evaluatorForRecursive )
+    public IntegerBinaryOperatorConvolutionCalculator( IConvolutionEvaluator<int> evaluatorForRecursive )
     {
         EvaluatorForRecursive = evaluatorForRecursive;
     }

--- a/Compiler/Domain/Ast/Analyzers/Convolutions/IntegerConditionalOperatorConvolutionEvaluator.cs
+++ b/Compiler/Domain/Ast/Analyzers/Convolutions/IntegerConditionalOperatorConvolutionEvaluator.cs
@@ -6,15 +6,15 @@ using KSPCompiler.Domain.Symbols.MetaData.Extensions;
 namespace KSPCompiler.Domain.Ast.Analyzers.Convolutions;
 
 /// <summary>
-/// Calculator for convolution operations with conditional operations
+/// Calculator for convolution operations with conditional operators
 /// </summary>
 /// <typeparam name="T">Configured conditional expression type (int/real etc.)</typeparam>
-public sealed class IntegerConvolutionConditionalEvaluator : IConvolutionConditionalEvaluator<int>
+public sealed class IntegerConditionalOperatorConvolutionEvaluator : IConvolutionConditionalEvaluator<int>
 {
     private IAstVisitor Visitor { get; }
     private IConvolutionEvaluator<int> ConvolutionEvaluator { get; }
 
-    public IntegerConvolutionConditionalEvaluator(
+    public IntegerConditionalOperatorConvolutionEvaluator(
         IAstVisitor visitor,
         IConvolutionEvaluator<int> convolutionEvaluator )
     {

--- a/Compiler/Domain/Ast/Analyzers/Convolutions/IntegerConvolutionEvaluator.cs
+++ b/Compiler/Domain/Ast/Analyzers/Convolutions/IntegerConvolutionEvaluator.cs
@@ -16,10 +16,10 @@ public sealed class IntegerConvolutionEvaluator : IConvolutionEvaluator<int>
 
     public IntegerConvolutionEvaluator( IAstVisitor visitor, ISymbolTable<VariableSymbol> variableSymbols, ICompilerMessageManger compilerMessageManger )
     {
-        OperandCalculator    = new IntegerConvolutionOperandCalculator( variableSymbols, compilerMessageManger );
-        BinaryCalculator     = new IntegerConvolutionBinaryCalculator( this );
-        UnaryCalculator      = new IntegerConvolutionUnaryCalculator( this );
-        ConditionalEvaluator = new IntegerConvolutionConditionalEvaluator( visitor, this );
+        OperandCalculator    = new IntegerOperandConvolutionCalculator( variableSymbols, compilerMessageManger );
+        BinaryCalculator     = new IntegerBinaryOperatorConvolutionCalculator( this );
+        UnaryCalculator      = new IntegerUnaryOperatorConvolutionCalculator( this );
+        ConditionalEvaluator = new IntegerConditionalOperatorConvolutionEvaluator( visitor, this );
     }
 
     public int? Evaluate( AstExpressionSyntaxNode expr, int workingValueForRecursive )

--- a/Compiler/Domain/Ast/Analyzers/Convolutions/IntegerOperandConvolutionCalculator.cs
+++ b/Compiler/Domain/Ast/Analyzers/Convolutions/IntegerOperandConvolutionCalculator.cs
@@ -13,12 +13,12 @@ namespace KSPCompiler.Domain.Ast.Analyzers.Convolutions;
 /// <summary>
 /// Calculator for convolution operations with integer operands
 /// </summary>
-public sealed class IntegerConvolutionOperandCalculator : IConvolutionOperandCalculator<int>
+public sealed class IntegerOperandConvolutionCalculator : IConvolutionOperandCalculator<int>
 {
     private ISymbolTable<VariableSymbol> VariableSymbols { get; }
     private ICompilerMessageManger CompilerMessageManger { get; }
 
-    public IntegerConvolutionOperandCalculator(
+    public IntegerOperandConvolutionCalculator(
         ISymbolTable<VariableSymbol> variableSymbols,
         ICompilerMessageManger compilerMessageManger )
     {

--- a/Compiler/Domain/Ast/Analyzers/Convolutions/IntegerUnaryOperatorConvolutionCalculator.cs
+++ b/Compiler/Domain/Ast/Analyzers/Convolutions/IntegerUnaryOperatorConvolutionCalculator.cs
@@ -5,18 +5,18 @@ using KSPCompiler.Domain.Ast.Nodes;
 namespace KSPCompiler.Domain.Ast.Analyzers.Convolutions;
 
 /// <summary>
-/// Calculator for convolution operations with unary operations
+/// Calculator for convolution operations with unary operators
 /// </summary>
-public sealed class RealConvolutionUnaryCalculator : IConvolutionUnaryCalculator<double>
+public sealed class IntegerUnaryOperatorConvolutionCalculator : IConvolutionUnaryCalculator<int>
 {
-    private IConvolutionEvaluator<double> EvaluatorForRecursive { get; }
+    private IConvolutionEvaluator<int> EvaluatorForRecursive { get; }
 
-    public RealConvolutionUnaryCalculator( IConvolutionEvaluator<double> evaluatorForRecursive )
+    public IntegerUnaryOperatorConvolutionCalculator( IConvolutionEvaluator<int> evaluatorForRecursive )
     {
         EvaluatorForRecursive = evaluatorForRecursive;
     }
 
-    public double? Calculate( AstExpressionSyntaxNode expr, double workingValueForRecursive )
+    public int? Calculate( AstExpressionSyntaxNode expr, int workingValueForRecursive )
     {
         if( expr.ChildNodeCount != 1 )
         {
@@ -34,6 +34,8 @@ public sealed class RealConvolutionUnaryCalculator : IConvolutionUnaryCalculator
         return expr.Id switch
         {
             AstNodeId.UnaryMinus     => -convolutedValue,
+            AstNodeId.UnaryNot        => ~convolutedValue,
+            AstNodeId.UnaryLogicalNot => convolutedValue != 0 ? 0 : 1, // C言語と同じ、0=false, 0以外が真をベースにしている
             _ => null
         };
     }

--- a/Compiler/Domain/Ast/Analyzers/Convolutions/RealBinaryOperatorConvolutionCalculator.cs
+++ b/Compiler/Domain/Ast/Analyzers/Convolutions/RealBinaryOperatorConvolutionCalculator.cs
@@ -5,13 +5,13 @@ using KSPCompiler.Domain.Ast.Nodes;
 namespace KSPCompiler.Domain.Ast.Analyzers.Convolutions;
 
 /// <summary>
-/// Calculator for convolution operations with binary operations
+/// Calculator for convolution operations with binary operators
 /// </summary>
-public sealed class RealConvolutionBinaryCalculator : IConvolutionBinaryCalculator<double>
+public sealed class RealBinaryOperatorConvolutionCalculator : IConvolutionBinaryCalculator<double>
 {
     private IConvolutionEvaluator<double> EvaluatorForRecursive { get; }
 
-    public RealConvolutionBinaryCalculator( IConvolutionEvaluator<double> evaluatorForRecursive )
+    public RealBinaryOperatorConvolutionCalculator( IConvolutionEvaluator<double> evaluatorForRecursive )
     {
         EvaluatorForRecursive = evaluatorForRecursive;
     }

--- a/Compiler/Domain/Ast/Analyzers/Convolutions/RealConditionalOperatorConvolutionEvaluator.cs
+++ b/Compiler/Domain/Ast/Analyzers/Convolutions/RealConditionalOperatorConvolutionEvaluator.cs
@@ -6,14 +6,14 @@ using KSPCompiler.Domain.Symbols.MetaData.Extensions;
 namespace KSPCompiler.Domain.Ast.Analyzers.Convolutions;
 
 /// <summary>
-/// Calculator for convolution operations with conditional operations
+/// Calculator for convolution operations with conditional operators
 /// </summary>
-public sealed class RealConvolutionConditionalEvaluator : IConvolutionConditionalEvaluator<double>
+public sealed class RealConditionalOperatorConvolutionEvaluator : IConvolutionConditionalEvaluator<double>
 {
     private IAstVisitor Visitor { get; }
     private IConvolutionEvaluator<double> ConvolutionEvaluator { get; }
 
-    public RealConvolutionConditionalEvaluator(
+    public RealConditionalOperatorConvolutionEvaluator(
         IAstVisitor visitor,
         IConvolutionEvaluator<double> convolutionEvaluator )
     {

--- a/Compiler/Domain/Ast/Analyzers/Convolutions/RealConvolutionEvaluator.cs
+++ b/Compiler/Domain/Ast/Analyzers/Convolutions/RealConvolutionEvaluator.cs
@@ -16,10 +16,10 @@ public sealed class RealConvolutionEvaluator : IConvolutionEvaluator<double>
 
     public RealConvolutionEvaluator( IAstVisitor visitor, ISymbolTable<VariableSymbol> variableSymbols, ICompilerMessageManger compilerMessageManger )
     {
-        OperandCalculator    = new RealConvolutionOperandCalculator( variableSymbols, compilerMessageManger );
-        BinaryCalculator     = new RealConvolutionBinaryCalculator( this );
-        UnaryCalculator      = new RealConvolutionUnaryCalculator( this );
-        ConditionalEvaluator = new RealConvolutionConditionalEvaluator( visitor, this );
+        OperandCalculator    = new RealOperandConvolutionCalculator( variableSymbols, compilerMessageManger );
+        BinaryCalculator     = new RealBinaryOperatorConvolutionCalculator( this );
+        UnaryCalculator      = new RealUnaryOperatorConvolutionCalculator( this );
+        ConditionalEvaluator = new RealConditionalOperatorConvolutionEvaluator( visitor, this );
     }
 
     public double? Evaluate( AstExpressionSyntaxNode expr, double workingValueForRecursive )

--- a/Compiler/Domain/Ast/Analyzers/Convolutions/RealOperandConvolutionCalculator.cs
+++ b/Compiler/Domain/Ast/Analyzers/Convolutions/RealOperandConvolutionCalculator.cs
@@ -13,12 +13,12 @@ namespace KSPCompiler.Domain.Ast.Analyzers.Convolutions;
 /// <summary>
 /// Calculator for convolution operations with KSP real (floating-point) operands
 /// </summary>
-public sealed class RealConvolutionOperandCalculator : IConvolutionOperandCalculator<double>
+public sealed class RealOperandConvolutionCalculator : IConvolutionOperandCalculator<double>
 {
     private ISymbolTable<VariableSymbol> VariableSymbols { get; }
     private ICompilerMessageManger CompilerMessageManger { get; }
 
-    public RealConvolutionOperandCalculator(
+    public RealOperandConvolutionCalculator(
         ISymbolTable<VariableSymbol> variableSymbols,
         ICompilerMessageManger compilerMessageManger )
     {

--- a/Compiler/Domain/Ast/Analyzers/Convolutions/RealUnaryOperatorConvolutionCalculator.cs
+++ b/Compiler/Domain/Ast/Analyzers/Convolutions/RealUnaryOperatorConvolutionCalculator.cs
@@ -5,18 +5,18 @@ using KSPCompiler.Domain.Ast.Nodes;
 namespace KSPCompiler.Domain.Ast.Analyzers.Convolutions;
 
 /// <summary>
-/// Calculator for convolution operations with unary operations
+/// Calculator for convolution operations with unary operators
 /// </summary>
-public sealed class IntegerConvolutionUnaryCalculator : IConvolutionUnaryCalculator<int>
+public sealed class RealUnaryOperatorConvolutionCalculator : IConvolutionUnaryCalculator<double>
 {
-    private IConvolutionEvaluator<int> EvaluatorForRecursive { get; }
+    private IConvolutionEvaluator<double> EvaluatorForRecursive { get; }
 
-    public IntegerConvolutionUnaryCalculator( IConvolutionEvaluator<int> evaluatorForRecursive )
+    public RealUnaryOperatorConvolutionCalculator( IConvolutionEvaluator<double> evaluatorForRecursive )
     {
         EvaluatorForRecursive = evaluatorForRecursive;
     }
 
-    public int? Calculate( AstExpressionSyntaxNode expr, int workingValueForRecursive )
+    public double? Calculate( AstExpressionSyntaxNode expr, double workingValueForRecursive )
     {
         if( expr.ChildNodeCount != 1 )
         {
@@ -34,8 +34,6 @@ public sealed class IntegerConvolutionUnaryCalculator : IConvolutionUnaryCalcula
         return expr.Id switch
         {
             AstNodeId.UnaryMinus     => -convolutedValue,
-            AstNodeId.UnaryNot        => ~convolutedValue,
-            AstNodeId.UnaryLogicalNot => convolutedValue != 0 ? 0 : 1, // C言語と同じ、0=false, 0以外が真をベースにしている
             _ => null
         };
     }


### PR DESCRIPTION
Old: ＜型＞Convolution＜演算子＞**
New: ＜型＞＜演算子＞Convolution**

Adjustment due to high cognitive load to read usage from the order of words in class names.

Old: `[Type]`Convolution`[Operator]`**
New: `[Type]` `[Operator]`Convolution**