### PR TITLE
refactor/astvisitor_reorganize

### DIFF
--- a/Compiler/Domain.Tests/Analyzer/Semantics/AstBooleanConvolutionEvaluatorTest.cs
+++ b/Compiler/Domain.Tests/Analyzer/Semantics/AstBooleanConvolutionEvaluatorTest.cs
@@ -22,7 +22,7 @@ public class AstBooleanConvolutionEvaluatorTest
             Right    = new AstIntLiteralNode( right )
         };
 
-        var result = booleanConvolutionEvaluator.Evaluate( ast, false );
+        var result = booleanConvolutionEvaluator.Evaluate( visitor, ast, false );
 
         Assert.IsNotNull( result );
         Assert.AreEqual( expected, result );
@@ -81,7 +81,7 @@ public class AstBooleanConvolutionEvaluatorTest
             Left     = new AstBooleanLiteralNode( value )
         };
 
-        var result = booleanConvolutionEvaluator.Evaluate( ast, false );
+        var result = booleanConvolutionEvaluator.Evaluate( visitor, ast, false );
 
         Assert.IsNotNull( result );
         Assert.AreEqual( !value, result );
@@ -113,7 +113,7 @@ public class AstBooleanConvolutionEvaluatorTest
             }
         };
 
-        var result = booleanConvolutionEvaluator.Evaluate( ast, false );
+        var result = booleanConvolutionEvaluator.Evaluate( visitor, ast, false );
 
         Assert.IsNotNull( result );
         Assert.AreEqual( expected, result );
@@ -145,7 +145,7 @@ public class AstBooleanConvolutionEvaluatorTest
             }
         };
 
-        var result = booleanConvolutionEvaluator.Evaluate( ast, false );
+        var result = booleanConvolutionEvaluator.Evaluate( visitor, ast, false );
 
         Assert.IsNotNull( result );
         Assert.AreEqual( expected, result );
@@ -179,7 +179,7 @@ public class AstBooleanConvolutionEvaluatorTest
             }
         };
 
-        var result = booleanConvolutionEvaluator.Evaluate( ast, false );
+        var result = booleanConvolutionEvaluator.Evaluate( visitor, ast, false );
 
         Assert.IsNotNull( result );
         Assert.AreEqual( expected, result );

--- a/Compiler/Domain.Tests/Analyzer/Semantics/AstConditionalUnaryOperatorConvolutionCalculatorTest.cs
+++ b/Compiler/Domain.Tests/Analyzer/Semantics/AstConditionalUnaryOperatorConvolutionCalculatorTest.cs
@@ -13,6 +13,7 @@ public class AstConditionalUnaryOperatorConvolutionCalculatorTest
     [TestCase( false )]
     public void ConvolutionIntegerConditionalOperatorTest( bool value )
     {
+        var visitor = new MockDefaultAstVisitor();
         var integerConvolutionEvaluator = new MockBooleanConvolutionEvaluator( value ); // always return `value`
 
         var calculator = new BooleanConditionalUnaryOperatorConvolutionCalculator(
@@ -25,7 +26,7 @@ public class AstConditionalUnaryOperatorConvolutionCalculatorTest
             Left     = new AstBooleanLiteralNode( value )
         };
 
-        var result = calculator.Calculate( ast );
+        var result = calculator.Calculate( visitor, ast );
 
         Assert.IsNotNull( result );
         Assert.AreEqual( !value, result );

--- a/Compiler/Domain.Tests/Analyzer/Semantics/AstIncompatibleBinaryOperatorEvaluationTest.cs
+++ b/Compiler/Domain.Tests/Analyzer/Semantics/AstIncompatibleBinaryOperatorEvaluationTest.cs
@@ -34,9 +34,10 @@ public class AstIncompatibleBinaryOperatorEvaluationTest
             compilerMessageManger
         );
         var realConvolutionEvaluator = new MockRealConvolutionEvaluator();
-        var binaryOperatorEvaluator = new NumericBinaryOperatorEvaluator( compilerMessageManger,
-                                                                          integerConvolutionEvaluator,
-                                                                          realConvolutionEvaluator
+        var binaryOperatorEvaluator = new NumericBinaryOperatorEvaluator(
+            compilerMessageManger,
+            integerConvolutionEvaluator,
+            realConvolutionEvaluator
         );
 
         visitor.Inject( binaryOperatorEvaluator );

--- a/Compiler/Domain.Tests/Analyzer/Semantics/AstIncompatibleBinaryOperatorEvaluationTest.cs
+++ b/Compiler/Domain.Tests/Analyzer/Semantics/AstIncompatibleBinaryOperatorEvaluationTest.cs
@@ -34,11 +34,9 @@ public class AstIncompatibleBinaryOperatorEvaluationTest
             compilerMessageManger
         );
         var realConvolutionEvaluator = new MockRealConvolutionEvaluator();
-        var binaryOperatorEvaluator = new NumericBinaryOperatorEvaluator(
-            visitor,
-            compilerMessageManger,
-            integerConvolutionEvaluator,
-            realConvolutionEvaluator
+        var binaryOperatorEvaluator = new NumericBinaryOperatorEvaluator( compilerMessageManger,
+                                                                          integerConvolutionEvaluator,
+                                                                          realConvolutionEvaluator
         );
 
         visitor.Inject( binaryOperatorEvaluator );

--- a/Compiler/Domain.Tests/Analyzer/Semantics/AstIntBinaryOperatorConvolutionTest.cs
+++ b/Compiler/Domain.Tests/Analyzer/Semantics/AstIntBinaryOperatorConvolutionTest.cs
@@ -26,11 +26,9 @@ public class AstIntBinaryOperatorConvolutionTest
             compilerMessageManger
         );
         var realConvolutionEvaluator = new MockRealConvolutionEvaluator();
-        var binaryOperatorEvaluator = new NumericBinaryOperatorEvaluator(
-            visitor,
-            compilerMessageManger,
-            integerConvolutionEvaluator,
-            realConvolutionEvaluator
+        var binaryOperatorEvaluator = new NumericBinaryOperatorEvaluator( compilerMessageManger,
+                                                                          integerConvolutionEvaluator,
+                                                                          realConvolutionEvaluator
         );
 
         visitor.Inject( binaryOperatorEvaluator );

--- a/Compiler/Domain.Tests/Analyzer/Semantics/AstIntBinaryOperatorConvolutionTest.cs
+++ b/Compiler/Domain.Tests/Analyzer/Semantics/AstIntBinaryOperatorConvolutionTest.cs
@@ -26,9 +26,10 @@ public class AstIntBinaryOperatorConvolutionTest
             compilerMessageManger
         );
         var realConvolutionEvaluator = new MockRealConvolutionEvaluator();
-        var binaryOperatorEvaluator = new NumericBinaryOperatorEvaluator( compilerMessageManger,
-                                                                          integerConvolutionEvaluator,
-                                                                          realConvolutionEvaluator
+        var binaryOperatorEvaluator = new NumericBinaryOperatorEvaluator(
+            compilerMessageManger,
+            integerConvolutionEvaluator,
+            realConvolutionEvaluator
         );
 
         visitor.Inject( binaryOperatorEvaluator );

--- a/Compiler/Domain.Tests/Analyzer/Semantics/AstIntBinaryOperatorEvaluationTest.cs
+++ b/Compiler/Domain.Tests/Analyzer/Semantics/AstIntBinaryOperatorEvaluationTest.cs
@@ -35,9 +35,10 @@ public class AstIntBinaryOperatorEvaluationTest
             compilerMessageManger
         );
         var realConvolutionEvaluator = new MockRealConvolutionEvaluator();
-        var binaryOperatorEvaluator = new NumericBinaryOperatorEvaluator( compilerMessageManger,
-                                                                          integerConvolutionEvaluator,
-                                                                          realConvolutionEvaluator
+        var binaryOperatorEvaluator = new NumericBinaryOperatorEvaluator(
+            compilerMessageManger,
+            integerConvolutionEvaluator,
+            realConvolutionEvaluator
         );
 
         visitor.Inject( binaryOperatorEvaluator );
@@ -68,9 +69,10 @@ public class AstIntBinaryOperatorEvaluationTest
             compilerMessageManger
         );
         var realConvolutionEvaluator = new MockRealConvolutionEvaluator();
-        var binaryOperatorEvaluator = new NumericBinaryOperatorEvaluator( compilerMessageManger,
-                                                                          integerConvolutionEvaluator,
-                                                                          realConvolutionEvaluator
+        var binaryOperatorEvaluator = new NumericBinaryOperatorEvaluator(
+            compilerMessageManger,
+            integerConvolutionEvaluator,
+            realConvolutionEvaluator
         );
 
         visitor.Inject( binaryOperatorEvaluator );
@@ -101,9 +103,10 @@ public class AstIntBinaryOperatorEvaluationTest
             compilerMessageManger
         );
         var realConvolutionEvaluator = new MockRealConvolutionEvaluator();
-        var binaryOperatorEvaluator = new NumericBinaryOperatorEvaluator( compilerMessageManger,
-                                                                          integerConvolutionEvaluator,
-                                                                          realConvolutionEvaluator
+        var binaryOperatorEvaluator = new NumericBinaryOperatorEvaluator(
+            compilerMessageManger,
+            integerConvolutionEvaluator,
+            realConvolutionEvaluator
         );
 
         visitor.Inject( binaryOperatorEvaluator );
@@ -134,9 +137,10 @@ public class AstIntBinaryOperatorEvaluationTest
             compilerMessageManger
         );
         var realConvolutionEvaluator = new MockRealConvolutionEvaluator();
-        var binaryOperatorEvaluator = new NumericBinaryOperatorEvaluator( compilerMessageManger,
-                                                                          integerConvolutionEvaluator,
-                                                                          realConvolutionEvaluator
+        var binaryOperatorEvaluator = new NumericBinaryOperatorEvaluator(
+            compilerMessageManger,
+            integerConvolutionEvaluator,
+            realConvolutionEvaluator
         );
 
         visitor.Inject( binaryOperatorEvaluator );
@@ -168,9 +172,10 @@ public class AstIntBinaryOperatorEvaluationTest
             compilerMessageManger
         );
         var realConvolutionEvaluator = new MockRealConvolutionEvaluator();
-        var binaryOperatorEvaluator = new NumericBinaryOperatorEvaluator( compilerMessageManger,
-                                                                          integerConvolutionEvaluator,
-                                                                          realConvolutionEvaluator
+        var binaryOperatorEvaluator = new NumericBinaryOperatorEvaluator(
+            compilerMessageManger,
+            integerConvolutionEvaluator,
+            realConvolutionEvaluator
         );
 
         visitor.Inject( binaryOperatorEvaluator );
@@ -204,9 +209,10 @@ public class AstIntBinaryOperatorEvaluationTest
             compilerMessageManger
         );
         var realConvolutionEvaluator = new MockRealConvolutionEvaluator();
-        var binaryOperatorEvaluator = new NumericBinaryOperatorEvaluator( compilerMessageManger,
-                                                                          integerConvolutionEvaluator,
-                                                                          realConvolutionEvaluator
+        var binaryOperatorEvaluator = new NumericBinaryOperatorEvaluator(
+            compilerMessageManger,
+            integerConvolutionEvaluator,
+            realConvolutionEvaluator
         );
 
         visitor.Inject( binaryOperatorEvaluator );
@@ -238,9 +244,10 @@ public class AstIntBinaryOperatorEvaluationTest
             compilerMessageManger
         );
         var realConvolutionEvaluator = new MockRealConvolutionEvaluator();
-        var binaryOperatorEvaluator = new NumericBinaryOperatorEvaluator( compilerMessageManger,
-                                                                          integerConvolutionEvaluator,
-                                                                          realConvolutionEvaluator
+        var binaryOperatorEvaluator = new NumericBinaryOperatorEvaluator(
+            compilerMessageManger,
+            integerConvolutionEvaluator,
+            realConvolutionEvaluator
         );
 
         visitor.Inject( binaryOperatorEvaluator );
@@ -272,9 +279,10 @@ public class AstIntBinaryOperatorEvaluationTest
             compilerMessageManger
         );
         var realConvolutionEvaluator = new MockRealConvolutionEvaluator();
-        var binaryOperatorEvaluator = new NumericBinaryOperatorEvaluator( compilerMessageManger,
-                                                                          integerConvolutionEvaluator,
-                                                                          realConvolutionEvaluator
+        var binaryOperatorEvaluator = new NumericBinaryOperatorEvaluator(
+            compilerMessageManger,
+            integerConvolutionEvaluator,
+            realConvolutionEvaluator
         );
 
         visitor.Inject( binaryOperatorEvaluator );

--- a/Compiler/Domain.Tests/Analyzer/Semantics/AstIntBinaryOperatorEvaluationTest.cs
+++ b/Compiler/Domain.Tests/Analyzer/Semantics/AstIntBinaryOperatorEvaluationTest.cs
@@ -35,11 +35,9 @@ public class AstIntBinaryOperatorEvaluationTest
             compilerMessageManger
         );
         var realConvolutionEvaluator = new MockRealConvolutionEvaluator();
-        var binaryOperatorEvaluator = new NumericBinaryOperatorEvaluator(
-            visitor,
-            compilerMessageManger,
-            integerConvolutionEvaluator,
-            realConvolutionEvaluator
+        var binaryOperatorEvaluator = new NumericBinaryOperatorEvaluator( compilerMessageManger,
+                                                                          integerConvolutionEvaluator,
+                                                                          realConvolutionEvaluator
         );
 
         visitor.Inject( binaryOperatorEvaluator );
@@ -70,11 +68,9 @@ public class AstIntBinaryOperatorEvaluationTest
             compilerMessageManger
         );
         var realConvolutionEvaluator = new MockRealConvolutionEvaluator();
-        var binaryOperatorEvaluator = new NumericBinaryOperatorEvaluator(
-            visitor,
-            compilerMessageManger,
-            integerConvolutionEvaluator,
-            realConvolutionEvaluator
+        var binaryOperatorEvaluator = new NumericBinaryOperatorEvaluator( compilerMessageManger,
+                                                                          integerConvolutionEvaluator,
+                                                                          realConvolutionEvaluator
         );
 
         visitor.Inject( binaryOperatorEvaluator );
@@ -105,11 +101,9 @@ public class AstIntBinaryOperatorEvaluationTest
             compilerMessageManger
         );
         var realConvolutionEvaluator = new MockRealConvolutionEvaluator();
-        var binaryOperatorEvaluator = new NumericBinaryOperatorEvaluator(
-            visitor,
-            compilerMessageManger,
-            integerConvolutionEvaluator,
-            realConvolutionEvaluator
+        var binaryOperatorEvaluator = new NumericBinaryOperatorEvaluator( compilerMessageManger,
+                                                                          integerConvolutionEvaluator,
+                                                                          realConvolutionEvaluator
         );
 
         visitor.Inject( binaryOperatorEvaluator );
@@ -140,11 +134,9 @@ public class AstIntBinaryOperatorEvaluationTest
             compilerMessageManger
         );
         var realConvolutionEvaluator = new MockRealConvolutionEvaluator();
-        var binaryOperatorEvaluator = new NumericBinaryOperatorEvaluator(
-            visitor,
-            compilerMessageManger,
-            integerConvolutionEvaluator,
-            realConvolutionEvaluator
+        var binaryOperatorEvaluator = new NumericBinaryOperatorEvaluator( compilerMessageManger,
+                                                                          integerConvolutionEvaluator,
+                                                                          realConvolutionEvaluator
         );
 
         visitor.Inject( binaryOperatorEvaluator );
@@ -176,11 +168,9 @@ public class AstIntBinaryOperatorEvaluationTest
             compilerMessageManger
         );
         var realConvolutionEvaluator = new MockRealConvolutionEvaluator();
-        var binaryOperatorEvaluator = new NumericBinaryOperatorEvaluator(
-            visitor,
-            compilerMessageManger,
-            integerConvolutionEvaluator,
-            realConvolutionEvaluator
+        var binaryOperatorEvaluator = new NumericBinaryOperatorEvaluator( compilerMessageManger,
+                                                                          integerConvolutionEvaluator,
+                                                                          realConvolutionEvaluator
         );
 
         visitor.Inject( binaryOperatorEvaluator );
@@ -214,11 +204,9 @@ public class AstIntBinaryOperatorEvaluationTest
             compilerMessageManger
         );
         var realConvolutionEvaluator = new MockRealConvolutionEvaluator();
-        var binaryOperatorEvaluator = new NumericBinaryOperatorEvaluator(
-            visitor,
-            compilerMessageManger,
-            integerConvolutionEvaluator,
-            realConvolutionEvaluator
+        var binaryOperatorEvaluator = new NumericBinaryOperatorEvaluator( compilerMessageManger,
+                                                                          integerConvolutionEvaluator,
+                                                                          realConvolutionEvaluator
         );
 
         visitor.Inject( binaryOperatorEvaluator );
@@ -250,11 +238,9 @@ public class AstIntBinaryOperatorEvaluationTest
             compilerMessageManger
         );
         var realConvolutionEvaluator = new MockRealConvolutionEvaluator();
-        var binaryOperatorEvaluator = new NumericBinaryOperatorEvaluator(
-            visitor,
-            compilerMessageManger,
-            integerConvolutionEvaluator,
-            realConvolutionEvaluator
+        var binaryOperatorEvaluator = new NumericBinaryOperatorEvaluator( compilerMessageManger,
+                                                                          integerConvolutionEvaluator,
+                                                                          realConvolutionEvaluator
         );
 
         visitor.Inject( binaryOperatorEvaluator );
@@ -286,11 +272,9 @@ public class AstIntBinaryOperatorEvaluationTest
             compilerMessageManger
         );
         var realConvolutionEvaluator = new MockRealConvolutionEvaluator();
-        var binaryOperatorEvaluator = new NumericBinaryOperatorEvaluator(
-            visitor,
-            compilerMessageManger,
-            integerConvolutionEvaluator,
-            realConvolutionEvaluator
+        var binaryOperatorEvaluator = new NumericBinaryOperatorEvaluator( compilerMessageManger,
+                                                                          integerConvolutionEvaluator,
+                                                                          realConvolutionEvaluator
         );
 
         visitor.Inject( binaryOperatorEvaluator );

--- a/Compiler/Domain.Tests/Analyzer/Semantics/AstIntUnaryOperatorEvaluationTest.cs
+++ b/Compiler/Domain.Tests/Analyzer/Semantics/AstIntUnaryOperatorEvaluationTest.cs
@@ -29,9 +29,10 @@ public class AstIntUnaryOperatorEvaluationTest
             compilerMessageManger
         );
         var realConvolutionEvaluator = new MockRealConvolutionEvaluator();
-        var unaryOperatorEvaluator = new NumericUnaryOperatorEvaluator( compilerMessageManger,
-                                                                        integerConvolutionEvaluator,
-                                                                        realConvolutionEvaluator
+        var unaryOperatorEvaluator = new NumericUnaryOperatorEvaluator(
+            compilerMessageManger,
+            integerConvolutionEvaluator,
+            realConvolutionEvaluator
         );
 
         visitor.Inject( unaryOperatorEvaluator );
@@ -61,9 +62,10 @@ public class AstIntUnaryOperatorEvaluationTest
             compilerMessageManger
         );
         var realConvolutionEvaluator = new MockRealConvolutionEvaluator();
-        var unaryOperatorEvaluator = new NumericUnaryOperatorEvaluator( compilerMessageManger,
-                                                                        integerConvolutionEvaluator,
-                                                                        realConvolutionEvaluator
+        var unaryOperatorEvaluator = new NumericUnaryOperatorEvaluator(
+            compilerMessageManger,
+            integerConvolutionEvaluator,
+            realConvolutionEvaluator
         );
 
         visitor.Inject( unaryOperatorEvaluator );

--- a/Compiler/Domain.Tests/Analyzer/Semantics/AstIntUnaryOperatorEvaluationTest.cs
+++ b/Compiler/Domain.Tests/Analyzer/Semantics/AstIntUnaryOperatorEvaluationTest.cs
@@ -29,11 +29,9 @@ public class AstIntUnaryOperatorEvaluationTest
             compilerMessageManger
         );
         var realConvolutionEvaluator = new MockRealConvolutionEvaluator();
-        var unaryOperatorEvaluator = new NumericUnaryOperatorEvaluator(
-            visitor,
-            compilerMessageManger,
-            integerConvolutionEvaluator,
-            realConvolutionEvaluator
+        var unaryOperatorEvaluator = new NumericUnaryOperatorEvaluator( compilerMessageManger,
+                                                                        integerConvolutionEvaluator,
+                                                                        realConvolutionEvaluator
         );
 
         visitor.Inject( unaryOperatorEvaluator );
@@ -63,11 +61,9 @@ public class AstIntUnaryOperatorEvaluationTest
             compilerMessageManger
         );
         var realConvolutionEvaluator = new MockRealConvolutionEvaluator();
-        var unaryOperatorEvaluator = new NumericUnaryOperatorEvaluator(
-            visitor,
-            compilerMessageManger,
-            integerConvolutionEvaluator,
-            realConvolutionEvaluator
+        var unaryOperatorEvaluator = new NumericUnaryOperatorEvaluator( compilerMessageManger,
+                                                                        integerConvolutionEvaluator,
+                                                                        realConvolutionEvaluator
         );
 
         visitor.Inject( unaryOperatorEvaluator );

--- a/Compiler/Domain.Tests/Analyzer/Semantics/AstIntegerConditionalBinaryOperatorConvolutionCalculatorTest.cs
+++ b/Compiler/Domain.Tests/Analyzer/Semantics/AstIntegerConditionalBinaryOperatorConvolutionCalculatorTest.cs
@@ -18,9 +18,7 @@ public class AstIntegerConditionalBinaryOperatorConvolutionCalculatorTest
         var visitor = new MockDefaultAstVisitor();
         var integerConvolutionEvaluator = new MockIntegerConvolutionEvaluator( value ); // always return `value`
 
-        var calulator = new IntegerConditionalBinaryOperatorConvolutionCalculator(
-            visitor,
-            integerConvolutionEvaluator
+        var calulator = new IntegerConditionalBinaryOperatorConvolutionCalculator( integerConvolutionEvaluator
         );
 
         var ast = new TNode
@@ -30,7 +28,7 @@ public class AstIntegerConditionalBinaryOperatorConvolutionCalculatorTest
             Right    = new AstIntLiteralNode( value )
         };
 
-        var result = calulator.Calculate( ast );
+        var result = calulator.Calculate( visitor, ast );
 
         Assert.IsNotNull( result );
         Assert.AreEqual( expected, result );

--- a/Compiler/Domain.Tests/Analyzer/Semantics/AstIntegerConditionalBinaryOperatorConvolutionCalculatorTest.cs
+++ b/Compiler/Domain.Tests/Analyzer/Semantics/AstIntegerConditionalBinaryOperatorConvolutionCalculatorTest.cs
@@ -18,8 +18,7 @@ public class AstIntegerConditionalBinaryOperatorConvolutionCalculatorTest
         var visitor = new MockDefaultAstVisitor();
         var integerConvolutionEvaluator = new MockIntegerConvolutionEvaluator( value ); // always return `value`
 
-        var calulator = new IntegerConditionalBinaryOperatorConvolutionCalculator( integerConvolutionEvaluator
-        );
+        var calulator = new IntegerConditionalBinaryOperatorConvolutionCalculator( integerConvolutionEvaluator );
 
         var ast = new TNode
         {

--- a/Compiler/Domain.Tests/Analyzer/Semantics/AstRealBinaryOperatorEvaluationTest.cs
+++ b/Compiler/Domain.Tests/Analyzer/Semantics/AstRealBinaryOperatorEvaluationTest.cs
@@ -34,11 +34,9 @@ public class AstRealBinaryOperatorEvaluationTest
             variableTable,
             compilerMessageManger
         );
-        var binaryOperatorEvaluator = new NumericBinaryOperatorEvaluator(
-            visitor,
-            compilerMessageManger,
-            integerConvolutionEvaluator,
-            realConvolutionEvaluator
+        var binaryOperatorEvaluator = new NumericBinaryOperatorEvaluator( compilerMessageManger,
+                                                                          integerConvolutionEvaluator,
+                                                                          realConvolutionEvaluator
         );
 
         visitor.Inject( binaryOperatorEvaluator );
@@ -70,11 +68,9 @@ public class AstRealBinaryOperatorEvaluationTest
             variableTable,
             compilerMessageManger
         );
-        var binaryOperatorEvaluator = new NumericBinaryOperatorEvaluator(
-            visitor,
-            compilerMessageManger,
-            integerConvolutionEvaluator,
-            realConvolutionEvaluator
+        var binaryOperatorEvaluator = new NumericBinaryOperatorEvaluator( compilerMessageManger,
+                                                                          integerConvolutionEvaluator,
+                                                                          realConvolutionEvaluator
         );
 
         visitor.Inject( binaryOperatorEvaluator );
@@ -106,11 +102,9 @@ public class AstRealBinaryOperatorEvaluationTest
             variableTable,
             compilerMessageManger
         );
-        var binaryOperatorEvaluator = new NumericBinaryOperatorEvaluator(
-            visitor,
-            compilerMessageManger,
-            integerConvolutionEvaluator,
-            realConvolutionEvaluator
+        var binaryOperatorEvaluator = new NumericBinaryOperatorEvaluator( compilerMessageManger,
+                                                                          integerConvolutionEvaluator,
+                                                                          realConvolutionEvaluator
         );
 
         visitor.Inject( binaryOperatorEvaluator );
@@ -142,11 +136,9 @@ public class AstRealBinaryOperatorEvaluationTest
             variableTable,
             compilerMessageManger
         );
-        var binaryOperatorEvaluator = new NumericBinaryOperatorEvaluator(
-            visitor,
-            compilerMessageManger,
-            integerConvolutionEvaluator,
-            realConvolutionEvaluator
+        var binaryOperatorEvaluator = new NumericBinaryOperatorEvaluator( compilerMessageManger,
+                                                                          integerConvolutionEvaluator,
+                                                                          realConvolutionEvaluator
         );
 
         visitor.Inject( binaryOperatorEvaluator );
@@ -182,11 +174,9 @@ public class AstRealBinaryOperatorEvaluationTest
             variableTable,
             compilerMessageManger
         );
-        var binaryOperatorEvaluator = new NumericBinaryOperatorEvaluator(
-            visitor,
-            compilerMessageManger,
-            integerConvolutionEvaluator,
-            realConvolutionEvaluator
+        var binaryOperatorEvaluator = new NumericBinaryOperatorEvaluator( compilerMessageManger,
+                                                                          integerConvolutionEvaluator,
+                                                                          realConvolutionEvaluator
         );
 
         visitor.Inject( binaryOperatorEvaluator );
@@ -218,11 +208,9 @@ public class AstRealBinaryOperatorEvaluationTest
             variableTable,
             compilerMessageManger
         );
-        var binaryOperatorEvaluator = new NumericBinaryOperatorEvaluator(
-            visitor,
-            compilerMessageManger,
-            integerConvolutionEvaluator,
-            realConvolutionEvaluator
+        var binaryOperatorEvaluator = new NumericBinaryOperatorEvaluator( compilerMessageManger,
+                                                                          integerConvolutionEvaluator,
+                                                                          realConvolutionEvaluator
         );
 
         visitor.Inject( binaryOperatorEvaluator );
@@ -254,11 +242,9 @@ public class AstRealBinaryOperatorEvaluationTest
             variableTable,
             compilerMessageManger
         );
-        var binaryOperatorEvaluator = new NumericBinaryOperatorEvaluator(
-            visitor,
-            compilerMessageManger,
-            integerConvolutionEvaluator,
-            realConvolutionEvaluator
+        var binaryOperatorEvaluator = new NumericBinaryOperatorEvaluator( compilerMessageManger,
+                                                                          integerConvolutionEvaluator,
+                                                                          realConvolutionEvaluator
         );
 
         visitor.Inject( binaryOperatorEvaluator );
@@ -290,11 +276,9 @@ public class AstRealBinaryOperatorEvaluationTest
             variableTable,
             compilerMessageManger
         );
-        var binaryOperatorEvaluator = new NumericBinaryOperatorEvaluator(
-            visitor,
-            compilerMessageManger,
-            integerConvolutionEvaluator,
-            realConvolutionEvaluator
+        var binaryOperatorEvaluator = new NumericBinaryOperatorEvaluator( compilerMessageManger,
+                                                                          integerConvolutionEvaluator,
+                                                                          realConvolutionEvaluator
         );
 
         visitor.Inject( binaryOperatorEvaluator );

--- a/Compiler/Domain.Tests/Analyzer/Semantics/AstRealBinaryOperatorEvaluationTest.cs
+++ b/Compiler/Domain.Tests/Analyzer/Semantics/AstRealBinaryOperatorEvaluationTest.cs
@@ -34,9 +34,10 @@ public class AstRealBinaryOperatorEvaluationTest
             variableTable,
             compilerMessageManger
         );
-        var binaryOperatorEvaluator = new NumericBinaryOperatorEvaluator( compilerMessageManger,
-                                                                          integerConvolutionEvaluator,
-                                                                          realConvolutionEvaluator
+        var binaryOperatorEvaluator = new NumericBinaryOperatorEvaluator(
+            compilerMessageManger,
+            integerConvolutionEvaluator,
+            realConvolutionEvaluator
         );
 
         visitor.Inject( binaryOperatorEvaluator );
@@ -68,9 +69,10 @@ public class AstRealBinaryOperatorEvaluationTest
             variableTable,
             compilerMessageManger
         );
-        var binaryOperatorEvaluator = new NumericBinaryOperatorEvaluator( compilerMessageManger,
-                                                                          integerConvolutionEvaluator,
-                                                                          realConvolutionEvaluator
+        var binaryOperatorEvaluator = new NumericBinaryOperatorEvaluator(
+            compilerMessageManger,
+            integerConvolutionEvaluator,
+            realConvolutionEvaluator
         );
 
         visitor.Inject( binaryOperatorEvaluator );
@@ -102,9 +104,10 @@ public class AstRealBinaryOperatorEvaluationTest
             variableTable,
             compilerMessageManger
         );
-        var binaryOperatorEvaluator = new NumericBinaryOperatorEvaluator( compilerMessageManger,
-                                                                          integerConvolutionEvaluator,
-                                                                          realConvolutionEvaluator
+        var binaryOperatorEvaluator = new NumericBinaryOperatorEvaluator(
+            compilerMessageManger,
+            integerConvolutionEvaluator,
+            realConvolutionEvaluator
         );
 
         visitor.Inject( binaryOperatorEvaluator );
@@ -136,9 +139,10 @@ public class AstRealBinaryOperatorEvaluationTest
             variableTable,
             compilerMessageManger
         );
-        var binaryOperatorEvaluator = new NumericBinaryOperatorEvaluator( compilerMessageManger,
-                                                                          integerConvolutionEvaluator,
-                                                                          realConvolutionEvaluator
+        var binaryOperatorEvaluator = new NumericBinaryOperatorEvaluator(
+            compilerMessageManger,
+            integerConvolutionEvaluator,
+            realConvolutionEvaluator
         );
 
         visitor.Inject( binaryOperatorEvaluator );
@@ -174,9 +178,10 @@ public class AstRealBinaryOperatorEvaluationTest
             variableTable,
             compilerMessageManger
         );
-        var binaryOperatorEvaluator = new NumericBinaryOperatorEvaluator( compilerMessageManger,
-                                                                          integerConvolutionEvaluator,
-                                                                          realConvolutionEvaluator
+        var binaryOperatorEvaluator = new NumericBinaryOperatorEvaluator(
+            compilerMessageManger,
+            integerConvolutionEvaluator,
+            realConvolutionEvaluator
         );
 
         visitor.Inject( binaryOperatorEvaluator );
@@ -208,9 +213,10 @@ public class AstRealBinaryOperatorEvaluationTest
             variableTable,
             compilerMessageManger
         );
-        var binaryOperatorEvaluator = new NumericBinaryOperatorEvaluator( compilerMessageManger,
-                                                                          integerConvolutionEvaluator,
-                                                                          realConvolutionEvaluator
+        var binaryOperatorEvaluator = new NumericBinaryOperatorEvaluator(
+            compilerMessageManger,
+            integerConvolutionEvaluator,
+            realConvolutionEvaluator
         );
 
         visitor.Inject( binaryOperatorEvaluator );
@@ -242,9 +248,10 @@ public class AstRealBinaryOperatorEvaluationTest
             variableTable,
             compilerMessageManger
         );
-        var binaryOperatorEvaluator = new NumericBinaryOperatorEvaluator( compilerMessageManger,
-                                                                          integerConvolutionEvaluator,
-                                                                          realConvolutionEvaluator
+        var binaryOperatorEvaluator = new NumericBinaryOperatorEvaluator(
+            compilerMessageManger,
+            integerConvolutionEvaluator,
+            realConvolutionEvaluator
         );
 
         visitor.Inject( binaryOperatorEvaluator );
@@ -276,9 +283,10 @@ public class AstRealBinaryOperatorEvaluationTest
             variableTable,
             compilerMessageManger
         );
-        var binaryOperatorEvaluator = new NumericBinaryOperatorEvaluator( compilerMessageManger,
-                                                                          integerConvolutionEvaluator,
-                                                                          realConvolutionEvaluator
+        var binaryOperatorEvaluator = new NumericBinaryOperatorEvaluator(
+            compilerMessageManger,
+            integerConvolutionEvaluator,
+            realConvolutionEvaluator
         );
 
         visitor.Inject( binaryOperatorEvaluator );

--- a/Compiler/Domain.Tests/Analyzer/Semantics/AstRealConditionalBinaryOperatorConvolutionCalculatorTest.cs
+++ b/Compiler/Domain.Tests/Analyzer/Semantics/AstRealConditionalBinaryOperatorConvolutionCalculatorTest.cs
@@ -17,7 +17,6 @@ public class AstRealConditionalBinaryOperatorConvolutionCalculatorTest
         var realConvolutionEvaluator = new MockRealConvolutionEvaluator( value ); // always return `value`
 
         var calulator = new RealConditionalBinaryOperatorConvolutionCalculator(
-            visitor,
             realConvolutionEvaluator
         );
 
@@ -28,7 +27,7 @@ public class AstRealConditionalBinaryOperatorConvolutionCalculatorTest
             Right    = new AstRealLiteralNode( value )
         };
 
-        var result = calulator.Calculate( ast );
+        var result = calulator.Calculate( visitor, ast );
 
         Assert.IsNotNull( result );
         Assert.AreEqual( expected, result );

--- a/Compiler/Domain.Tests/Analyzer/Semantics/AstRealUnaryOperatorEvaluationTest.cs
+++ b/Compiler/Domain.Tests/Analyzer/Semantics/AstRealUnaryOperatorEvaluationTest.cs
@@ -29,11 +29,9 @@ public class AstRealUnaryOperatorEvaluationTest
             variableTable,
             compilerMessageManger
         );
-        var unaryOperatorEvaluator = new NumericUnaryOperatorEvaluator(
-            visitor,
-            compilerMessageManger,
-            integerConvolutionEvaluator,
-            realConvolutionEvaluator
+        var unaryOperatorEvaluator = new NumericUnaryOperatorEvaluator( compilerMessageManger,
+                                                                        integerConvolutionEvaluator,
+                                                                        realConvolutionEvaluator
         );
 
         visitor.Inject( unaryOperatorEvaluator );
@@ -63,11 +61,9 @@ public class AstRealUnaryOperatorEvaluationTest
             variableTable,
             compilerMessageManger
         );
-        var unaryOperatorEvaluator = new NumericUnaryOperatorEvaluator(
-            visitor,
-            compilerMessageManger,
-            integerConvolutionEvaluator,
-            realConvolutionEvaluator
+        var unaryOperatorEvaluator = new NumericUnaryOperatorEvaluator( compilerMessageManger,
+                                                                        integerConvolutionEvaluator,
+                                                                        realConvolutionEvaluator
         );
 
         visitor.Inject( unaryOperatorEvaluator );

--- a/Compiler/Domain.Tests/Analyzer/Semantics/AstRealUnaryOperatorEvaluationTest.cs
+++ b/Compiler/Domain.Tests/Analyzer/Semantics/AstRealUnaryOperatorEvaluationTest.cs
@@ -29,9 +29,10 @@ public class AstRealUnaryOperatorEvaluationTest
             variableTable,
             compilerMessageManger
         );
-        var unaryOperatorEvaluator = new NumericUnaryOperatorEvaluator( compilerMessageManger,
-                                                                        integerConvolutionEvaluator,
-                                                                        realConvolutionEvaluator
+        var unaryOperatorEvaluator = new NumericUnaryOperatorEvaluator(
+            compilerMessageManger,
+            integerConvolutionEvaluator,
+            realConvolutionEvaluator
         );
 
         visitor.Inject( unaryOperatorEvaluator );
@@ -61,9 +62,10 @@ public class AstRealUnaryOperatorEvaluationTest
             variableTable,
             compilerMessageManger
         );
-        var unaryOperatorEvaluator = new NumericUnaryOperatorEvaluator( compilerMessageManger,
-                                                                        integerConvolutionEvaluator,
-                                                                        realConvolutionEvaluator
+        var unaryOperatorEvaluator = new NumericUnaryOperatorEvaluator(
+            compilerMessageManger,
+            integerConvolutionEvaluator,
+            realConvolutionEvaluator
         );
 
         visitor.Inject( unaryOperatorEvaluator );

--- a/Compiler/Domain.Tests/Analyzer/Semantics/AstStringConcatenateOperatorTest.cs
+++ b/Compiler/Domain.Tests/Analyzer/Semantics/AstStringConcatenateOperatorTest.cs
@@ -27,10 +27,8 @@ public class AstStringConcatenateOperatorTest
             variableTable,
             compilerMessageManger
         );
-        var unaryOperatorEvaluator = new StringConcatenateOperatorEvaluator(
-            visitor,
-            compilerMessageManger,
-            integerConvolutionEvaluator
+        var unaryOperatorEvaluator = new StringConcatenateOperatorEvaluator( compilerMessageManger,
+                                                                             integerConvolutionEvaluator
         );
 
         visitor.Inject( unaryOperatorEvaluator );
@@ -66,10 +64,8 @@ public class AstStringConcatenateOperatorTest
             variableTable,
             compilerMessageManger
         );
-        var unaryOperatorEvaluator = new StringConcatenateOperatorEvaluator(
-            visitor,
-            compilerMessageManger,
-            integerConvolutionEvaluator
+        var unaryOperatorEvaluator = new StringConcatenateOperatorEvaluator( compilerMessageManger,
+                                                                             integerConvolutionEvaluator
         );
 
         visitor.Inject( unaryOperatorEvaluator );

--- a/Compiler/Domain.Tests/Analyzer/Semantics/AstStringConcatenateOperatorTest.cs
+++ b/Compiler/Domain.Tests/Analyzer/Semantics/AstStringConcatenateOperatorTest.cs
@@ -27,8 +27,9 @@ public class AstStringConcatenateOperatorTest
             variableTable,
             compilerMessageManger
         );
-        var unaryOperatorEvaluator = new StringConcatenateOperatorEvaluator( compilerMessageManger,
-                                                                             integerConvolutionEvaluator
+        var unaryOperatorEvaluator = new StringConcatenateOperatorEvaluator(
+            compilerMessageManger,
+            integerConvolutionEvaluator
         );
 
         visitor.Inject( unaryOperatorEvaluator );
@@ -64,8 +65,9 @@ public class AstStringConcatenateOperatorTest
             variableTable,
             compilerMessageManger
         );
-        var unaryOperatorEvaluator = new StringConcatenateOperatorEvaluator( compilerMessageManger,
-                                                                             integerConvolutionEvaluator
+        var unaryOperatorEvaluator = new StringConcatenateOperatorEvaluator(
+            compilerMessageManger,
+            integerConvolutionEvaluator
         );
 
         visitor.Inject( unaryOperatorEvaluator );

--- a/Compiler/Domain.Tests/Analyzer/Semantics/MockArrayElementEvaluator.cs
+++ b/Compiler/Domain.Tests/Analyzer/Semantics/MockArrayElementEvaluator.cs
@@ -15,6 +15,6 @@ internal class MockArrayElementEvaluator : IArrayElementEvaluator
         EvalResult = evalResult;
     }
 
-    public IAstNode Evaluate( IAstVisitor<IAstNode> visitor, AstArrayElementExpressionNode expr )
+    public IAstNode Evaluate( IAstVisitor visitor, AstArrayElementExpressionNode expr )
         => EvalResult;
 }

--- a/Compiler/Domain.Tests/Analyzer/Semantics/MockAssignOperatorEvaluator.cs
+++ b/Compiler/Domain.Tests/Analyzer/Semantics/MockAssignOperatorEvaluator.cs
@@ -7,7 +7,7 @@ namespace KSPCompiler.Domain.Tests.Analyzer.Semantics;
 
 public class MockAssignOperatorEvaluator : IAssignOperatorEvaluator
 {
-    public IAstNode Evaluate( IAstVisitor<IAstNode> visitor, AstExpressionNode expr )
+    public IAstNode Evaluate( IAstVisitor visitor, AstExpressionNode expr )
     {
         throw new NotImplementedException();
     }

--- a/Compiler/Domain.Tests/Analyzer/Semantics/MockBinaryOperatorEvaluator.cs
+++ b/Compiler/Domain.Tests/Analyzer/Semantics/MockBinaryOperatorEvaluator.cs
@@ -7,6 +7,6 @@ namespace KSPCompiler.Domain.Tests.Analyzer.Semantics;
 
 public class MockBinaryOperatorEvaluator : IBinaryOperatorEvaluator
 {
-    public IAstNode Evaluate( IAstVisitor<IAstNode> visitor, AstExpressionNode expr )
+    public IAstNode Evaluate( IAstVisitor visitor, AstExpressionNode expr )
         => throw new NotImplementedException();
 }

--- a/Compiler/Domain.Tests/Analyzer/Semantics/MockBooleanConvolutionEvaluator.cs
+++ b/Compiler/Domain.Tests/Analyzer/Semantics/MockBooleanConvolutionEvaluator.cs
@@ -14,6 +14,6 @@ public class MockBooleanConvolutionEvaluator : IBooleanConvolutionEvaluator
         Result = result;
     }
 
-    public bool? Evaluate( AstExpressionNode expr, bool workingValueForRecursive )
+    public bool? Evaluate( IAstVisitor visitor, AstExpressionNode expr, bool workingValueForRecursive )
         => Result;
 }

--- a/Compiler/Domain.Tests/Analyzer/Semantics/MockCallCommandExpressionEvaluator.cs
+++ b/Compiler/Domain.Tests/Analyzer/Semantics/MockCallCommandExpressionEvaluator.cs
@@ -6,6 +6,6 @@ namespace KSPCompiler.Domain.Tests.Analyzer.Semantics;
 
 internal class MockCallCommandExpressionEvaluator : ICallCommandExpressionEvaluator
 {
-    public IAstNode Evaluate( IAstVisitor<IAstNode> visitor, AstCallCommandExpressionNode node )
+    public IAstNode Evaluate( IAstVisitor visitor, AstCallCommandExpressionNode node )
         => throw new System.NotImplementedException();
 }

--- a/Compiler/Domain.Tests/Analyzer/Semantics/MockConditionalBinaryOperatorEvaluator.cs
+++ b/Compiler/Domain.Tests/Analyzer/Semantics/MockConditionalBinaryOperatorEvaluator.cs
@@ -7,6 +7,6 @@ namespace KSPCompiler.Domain.Tests.Analyzer.Semantics;
 
 public class MockConditionalBinaryOperatorEvaluator : IBinaryOperatorEvaluator
 {
-    public IAstNode Evaluate( IAstVisitor<IAstNode> visitor, AstExpressionNode expr )
+    public IAstNode Evaluate( IAstVisitor visitor, AstExpressionNode expr )
         => throw new NotImplementedException();
 }

--- a/Compiler/Domain.Tests/Analyzer/Semantics/MockConditionalConvolutionEvaluator.cs
+++ b/Compiler/Domain.Tests/Analyzer/Semantics/MockConditionalConvolutionEvaluator.cs
@@ -14,6 +14,6 @@ public class MockConditionalConvolutionEvaluator : IConditionalConvolutionEvalua
         Result = result;
     }
 
-    public bool? Evaluate( AstExpressionNode expr, bool workingValueForRecursive )
+    public bool? Evaluate( IAstVisitor visitor, AstExpressionNode expr, bool workingValueForRecursive )
         => Result;
 }

--- a/Compiler/Domain.Tests/Analyzer/Semantics/MockConditionalLogicalOperatorEvaluator.cs
+++ b/Compiler/Domain.Tests/Analyzer/Semantics/MockConditionalLogicalOperatorEvaluator.cs
@@ -7,6 +7,6 @@ namespace KSPCompiler.Domain.Tests.Analyzer.Semantics;
 
 public class MockConditionalLogicalOperatorEvaluator : IConditionalLogicalOperatorEvaluator
 {
-    public IAstNode Evaluate( IAstVisitor<IAstNode> visitor, AstExpressionNode expr )
+    public IAstNode Evaluate( IAstVisitor visitor, AstExpressionNode expr )
         => throw new NotImplementedException();
 }

--- a/Compiler/Domain.Tests/Analyzer/Semantics/MockConditionalUnaryOperatorEvaluator.cs
+++ b/Compiler/Domain.Tests/Analyzer/Semantics/MockConditionalUnaryOperatorEvaluator.cs
@@ -7,6 +7,6 @@ namespace KSPCompiler.Domain.Tests.Analyzer.Semantics;
 
 public class MockConditionalUnaryOperatorEvaluator : IUnaryOperatorEvaluator
 {
-    public IAstNode Evaluate( IAstVisitor<IAstNode> visitor, AstExpressionNode expr )
+    public IAstNode Evaluate( IAstVisitor visitor, AstExpressionNode expr )
         => throw new NotImplementedException();
 }

--- a/Compiler/Domain.Tests/Analyzer/Semantics/MockIntegerConvolutionEvaluator.cs
+++ b/Compiler/Domain.Tests/Analyzer/Semantics/MockIntegerConvolutionEvaluator.cs
@@ -14,6 +14,6 @@ public class MockIntegerConvolutionEvaluator : IIntegerConvolutionEvaluator
         Result = result;
     }
 
-    public int? Evaluate( AstExpressionNode expr, int workingValueForRecursive )
+    public int? Evaluate( IAstVisitor visitor, AstExpressionNode expr, int workingValueForRecursive )
         => Result;
 }

--- a/Compiler/Domain.Tests/Analyzer/Semantics/MockRealConvolutionEvaluator.cs
+++ b/Compiler/Domain.Tests/Analyzer/Semantics/MockRealConvolutionEvaluator.cs
@@ -14,6 +14,6 @@ public class MockRealConvolutionEvaluator : IRealConvolutionEvaluator
         Result = result;
     }
 
-    public double? Evaluate( AstExpressionNode expr, double workingValueForRecursive )
+    public double? Evaluate( IAstVisitor visitor, AstExpressionNode expr, double workingValueForRecursive )
         => Result;
 }

--- a/Compiler/Domain.Tests/Analyzer/Semantics/MockStringConcatenateOperatorEvaluator.cs
+++ b/Compiler/Domain.Tests/Analyzer/Semantics/MockStringConcatenateOperatorEvaluator.cs
@@ -7,6 +7,6 @@ namespace KSPCompiler.Domain.Tests.Analyzer.Semantics;
 
 public class MockStringConcatenateOperatorEvaluator : IStringConcatenateOperatorEvaluator
 {
-    public IAstNode Evaluate( IAstVisitor<IAstNode> visitor, AstExpressionNode expr )
+    public IAstNode Evaluate( IAstVisitor visitor, AstExpressionNode expr )
         => throw new NotImplementedException();
 }

--- a/Compiler/Domain.Tests/Analyzer/Semantics/MockStringConvolutionEvaluator.cs
+++ b/Compiler/Domain.Tests/Analyzer/Semantics/MockStringConvolutionEvaluator.cs
@@ -14,6 +14,6 @@ public class MockStringConvolutionEvaluator : IStringConvolutionEvaluator
         Result = result;
     }
 
-    public string? Evaluate( AstExpressionNode expr, string workingValueForRecursive )
+    public string? Evaluate( IAstVisitor visitor, AstExpressionNode expr, string workingValueForRecursive )
         => Result;
 }

--- a/Compiler/Domain.Tests/Analyzer/Semantics/MockSymbolEvaluator.cs
+++ b/Compiler/Domain.Tests/Analyzer/Semantics/MockSymbolEvaluator.cs
@@ -15,6 +15,6 @@ internal class MockSymbolEvaluator : ISymbolEvaluator
         EvalResult = evalResult;
     }
 
-    public IAstNode Evaluate( IAstVisitor<IAstNode> visitor, AstSymbolExpressionNode expr )
+    public IAstNode Evaluate( IAstVisitor visitor, AstSymbolExpressionNode expr )
         => EvalResult;
 }

--- a/Compiler/Domain.Tests/Analyzer/Semantics/MockUnaryOperatorEvaluator.cs
+++ b/Compiler/Domain.Tests/Analyzer/Semantics/MockUnaryOperatorEvaluator.cs
@@ -7,6 +7,6 @@ namespace KSPCompiler.Domain.Tests.Analyzer.Semantics;
 
 public class MockUnaryOperatorEvaluator : IUnaryOperatorEvaluator
 {
-    public IAstNode Evaluate( IAstVisitor<IAstNode> visitor, AstExpressionNode expr )
+    public IAstNode Evaluate( IAstVisitor visitor, AstExpressionNode expr )
         => throw new NotImplementedException();
 }

--- a/Compiler/Domain.Tests/Analyzer/Semantics/MockUtility.cs
+++ b/Compiler/Domain.Tests/Analyzer/Semantics/MockUtility.cs
@@ -342,10 +342,10 @@ public static class MockUtility
         var symbols = MockUtility.CreateAggregateSymbolTable();
 
         var integerConvolutionEvaluator = new IntegerConvolutionEvaluator( visitor, symbols.Variables, compilerMessageManger );
-        var integerConditionalBinaryOperatorConvolutionCalculator = new IntegerConditionalBinaryOperatorConvolutionCalculator( visitor, integerConvolutionEvaluator );
+        var integerConditionalBinaryOperatorConvolutionCalculator = new IntegerConditionalBinaryOperatorConvolutionCalculator( integerConvolutionEvaluator );
 
         var realConvolutionEvaluator = new RealConvolutionEvaluator( visitor, symbols.Variables, compilerMessageManger );
-        var realConditionalBinaryOperatorConvolutionCalculator = new RealConditionalBinaryOperatorConvolutionCalculator( visitor, realConvolutionEvaluator );
+        var realConditionalBinaryOperatorConvolutionCalculator = new RealConditionalBinaryOperatorConvolutionCalculator( realConvolutionEvaluator );
 
         return  new BooleanConvolutionEvaluator(
             visitor,

--- a/Compiler/Domain/Ast/Analyzers/Evaluators/Commands/ICallCommandExpressionEvaluator.cs
+++ b/Compiler/Domain/Ast/Analyzers/Evaluators/Commands/ICallCommandExpressionEvaluator.cs
@@ -3,9 +3,7 @@ using KSPCompiler.Domain.Ast.Nodes.Expressions;
 
 namespace KSPCompiler.Domain.Ast.Analyzers.Evaluators.Commands;
 
-public interface ICallCommandExpressionEvaluator<TEvalResult>
+public interface ICallCommandExpressionEvaluator
 {
-    public TEvalResult Evaluate( IAstVisitor<TEvalResult> visitor, AstCallCommandExpressionNode node );
+    public IAstNode Evaluate( IAstVisitor visitor, AstCallCommandExpressionNode node );
 }
-
-public interface ICallCommandExpressionEvaluator : ICallCommandExpressionEvaluator<IAstNode> {}

--- a/Compiler/Domain/Ast/Analyzers/Evaluators/Convolutions/Booleans/BooleanConditionalUnaryOperatorConvolutionCalculator.cs
+++ b/Compiler/Domain/Ast/Analyzers/Evaluators/Convolutions/Booleans/BooleanConditionalUnaryOperatorConvolutionCalculator.cs
@@ -16,14 +16,14 @@ public class BooleanConditionalUnaryOperatorConvolutionCalculator : IBooleanCond
         EvaluatorForRecursive = evaluatorForRecursive;
     }
 
-    public bool? Calculate( AstExpressionNode expr )
+    public bool? Calculate( IAstVisitor visitor, AstExpressionNode expr )
     {
         if( expr.ChildNodeCount != 1 )
         {
             throw new ArgumentException( $"Expected 1 child node, but got {expr.ChildNodeCount}. (node: {expr.GetType().Name})" );
         }
 
-        var convolutedValue = EvaluatorForRecursive.Evaluate( expr.Left, false );
+        var convolutedValue = EvaluatorForRecursive.Evaluate( visitor, expr.Left, false );
 
         if( convolutedValue == null )
         {

--- a/Compiler/Domain/Ast/Analyzers/Evaluators/Convolutions/Booleans/BooleanConstantConvolutionCalculator.cs
+++ b/Compiler/Domain/Ast/Analyzers/Evaluators/Convolutions/Booleans/BooleanConstantConvolutionCalculator.cs
@@ -10,7 +10,7 @@ namespace KSPCompiler.Domain.Ast.Analyzers.Evaluators.Convolutions.Booleans;
 /// </summary>
 public class BooleanConstantConvolutionCalculator : IBooleanConstantConvolutionCalculator
 {
-    public bool? Calculate( AstExpressionNode expr, bool workingValueForRecursive )
+    public bool? Calculate( IAstVisitor visitor, AstExpressionNode expr, bool workingValueForRecursive )
     {
         if( expr.ChildNodeCount != 0 )
         {

--- a/Compiler/Domain/Ast/Analyzers/Evaluators/Convolutions/Booleans/BooleanConvolutionEvaluator.cs
+++ b/Compiler/Domain/Ast/Analyzers/Evaluators/Convolutions/Booleans/BooleanConvolutionEvaluator.cs
@@ -7,7 +7,6 @@ namespace KSPCompiler.Domain.Ast.Analyzers.Evaluators.Convolutions.Booleans;
 
 public class BooleanConvolutionEvaluator : IBooleanConvolutionEvaluator
 {
-    private IAstVisitor Visitor { get; }
     private IBooleanConstantConvolutionCalculator ConstantConvolutionCalculator { get; }
     private IIntegerConditionalBinaryOperatorConvolutionCalculator IntegerBinaryOperatorCalculator { get; }
     private IRealConditionalBinaryOperatorConvolutionCalculator RealBinaryOperatorCalculator { get; }
@@ -19,8 +18,6 @@ public class BooleanConvolutionEvaluator : IBooleanConvolutionEvaluator
         IIntegerConditionalBinaryOperatorConvolutionCalculator integerConvolutionEvaluator,
         IRealConditionalBinaryOperatorConvolutionCalculator realConvolutionEvaluator )
     {
-        Visitor = visitor;
-
         ConstantConvolutionCalculator    = new BooleanConstantConvolutionCalculator();
         IntegerBinaryOperatorCalculator  = integerConvolutionEvaluator;
         RealBinaryOperatorCalculator     = realConvolutionEvaluator;
@@ -28,41 +25,41 @@ public class BooleanConvolutionEvaluator : IBooleanConvolutionEvaluator
         BooleanUnaryOperatorCalculator   = new BooleanConditionalUnaryOperatorConvolutionCalculator( this );
     }
 
-    public bool? Evaluate( AstExpressionNode expr, bool workingValueForRecursive )
+    public bool? Evaluate( IAstVisitor visitor, AstExpressionNode expr, bool workingValueForRecursive )
     {
         var id = expr.Id;
 
         if( expr.ChildNodeCount == 0 )
         {
-            return ConstantConvolutionCalculator.Calculate( expr, workingValueForRecursive );
+            return ConstantConvolutionCalculator.Calculate( visitor, expr, workingValueForRecursive );
         }
 
         if( id.IsBooleanSupportedBinaryOperator() )
         {
-            return CalculateBinaryOperator( expr );
+            return CalculateBinaryOperator( visitor, expr );
         }
 
         if( id.IsBooleanSupportedUnaryOperator() )
         {
-            return BooleanUnaryOperatorCalculator.Calculate( expr );
+            return BooleanUnaryOperatorCalculator.Calculate( visitor, expr );
         }
 
         if( id.IsConditionalLogicalOperator() )
         {
-            return BooleanLogicalOperatorCalculator.Calculate( expr );
+            return BooleanLogicalOperatorCalculator.Calculate( visitor, expr );
         }
 
         return null;
     }
 
-    private bool? CalculateBinaryOperator( AstExpressionNode expr )
+    private bool? CalculateBinaryOperator( IAstVisitor visitor, AstExpressionNode expr )
     {
-        if( expr.Left.Accept( Visitor ) is not AstExpressionNode evaluatedLeft )
+        if( expr.Left.Accept( visitor ) is not AstExpressionNode evaluatedLeft )
         {
             return null;
         }
 
-        if( expr.Right.Accept( Visitor ) is not AstExpressionNode evaluatedRight )
+        if( expr.Right.Accept( visitor ) is not AstExpressionNode evaluatedRight )
         {
             return null;
         }
@@ -77,17 +74,17 @@ public class BooleanConvolutionEvaluator : IBooleanConvolutionEvaluator
 
         if( leftType.IsInt() )
         {
-            return IntegerBinaryOperatorCalculator.Calculate( expr );
+            return IntegerBinaryOperatorCalculator.Calculate( visitor, expr );
         }
 
         if( leftType.IsReal() )
         {
-            return RealBinaryOperatorCalculator.Calculate( expr );
+            return RealBinaryOperatorCalculator.Calculate( visitor, expr );
         }
 
         if( leftType.IsBoolean() )
         {
-            return BooleanLogicalOperatorCalculator.Calculate( expr );
+            return BooleanLogicalOperatorCalculator.Calculate( visitor, expr );
         }
 
         return null;

--- a/Compiler/Domain/Ast/Analyzers/Evaluators/Convolutions/Conditions/ConditionalLogicalOperatorConvolutionCalculator.cs
+++ b/Compiler/Domain/Ast/Analyzers/Evaluators/Convolutions/Conditions/ConditionalLogicalOperatorConvolutionCalculator.cs
@@ -8,7 +8,6 @@ namespace KSPCompiler.Domain.Ast.Analyzers.Evaluators.Convolutions.Conditions;
 
 public class ConditionalLogicalOperatorConvolutionCalculator : IConditionalLogicalOperatorConvolutionCalculator
 {
-    private IAstVisitor Visitor { get; }
     private IBooleanConvolutionEvaluator ConvolutionEvaluator { get; }
 
     public ConditionalLogicalOperatorConvolutionCalculator(
@@ -16,18 +15,17 @@ public class ConditionalLogicalOperatorConvolutionCalculator : IConditionalLogic
         IBooleanConvolutionEvaluator convolutionEvaluator )
     {
         ConvolutionEvaluator = convolutionEvaluator;
-        Visitor              = visitor;
     }
 
-    public bool? Calculate( AstExpressionNode expr )
+    public bool? Calculate( IAstVisitor visitor, AstExpressionNode expr )
     {
         if( expr.ChildNodeCount != 2 )
         {
             throw new ArgumentException( $"Expected 2 child nodes, but got {expr.ChildNodeCount}. (node: {expr.GetType().Name})" );
         }
 
-        var exprLeft = expr.Left.Accept( Visitor ) as AstExpressionNode;
-        var exprRight = expr.Right.Accept( Visitor ) as AstExpressionNode;
+        var exprLeft = expr.Left.Accept( visitor ) as AstExpressionNode;
+        var exprRight = expr.Right.Accept( visitor ) as AstExpressionNode;
 
         if( exprLeft == null || exprRight == null )
         {
@@ -40,8 +38,8 @@ public class ConditionalLogicalOperatorConvolutionCalculator : IConditionalLogic
             return null;
         }
 
-        var convolutedLeft = ConvolutionEvaluator.Evaluate( exprLeft,   false );
-        var convolutedRight = ConvolutionEvaluator.Evaluate( exprRight, false );
+        var convolutedLeft = ConvolutionEvaluator.Evaluate( visitor, exprLeft,   false );
+        var convolutedRight = ConvolutionEvaluator.Evaluate( visitor, exprRight, false );
 
         if( convolutedLeft == null || convolutedRight == null )
         {

--- a/Compiler/Domain/Ast/Analyzers/Evaluators/Convolutions/Conditions/IntegerConditionalBinaryOperatorConvolutionCalculator.cs
+++ b/Compiler/Domain/Ast/Analyzers/Evaluators/Convolutions/Conditions/IntegerConditionalBinaryOperatorConvolutionCalculator.cs
@@ -11,26 +11,22 @@ namespace KSPCompiler.Domain.Ast.Analyzers.Evaluators.Convolutions.Conditions;
 /// </summary>
 public sealed class IntegerConditionalBinaryOperatorConvolutionCalculator : IIntegerConditionalBinaryOperatorConvolutionCalculator
 {
-    private IAstVisitor Visitor { get; }
     private IIntegerConvolutionEvaluator ConvolutionEvaluator { get; }
 
-    public IntegerConditionalBinaryOperatorConvolutionCalculator(
-        IAstVisitor visitor,
-        IIntegerConvolutionEvaluator convolutionEvaluator )
+    public IntegerConditionalBinaryOperatorConvolutionCalculator( IIntegerConvolutionEvaluator convolutionEvaluator )
     {
-        Visitor              = visitor;
         ConvolutionEvaluator = convolutionEvaluator;
     }
 
-    public bool? Calculate( AstExpressionNode expr )
+    public bool? Calculate( IAstVisitor visitor, AstExpressionNode expr )
     {
         if( expr.ChildNodeCount != 2 )
         {
             throw new ArgumentException( $"Expected 2 child nodes, but got {expr.ChildNodeCount}. (node: {expr.GetType().Name})" );
         }
 
-        var exprLeft = expr.Left.Accept( Visitor ) as AstExpressionNode;
-        var exprRight = expr.Right.Accept( Visitor ) as AstExpressionNode;
+        var exprLeft = expr.Left.Accept( visitor ) as AstExpressionNode;
+        var exprRight = expr.Right.Accept( visitor ) as AstExpressionNode;
 
         if( exprLeft == null || exprRight == null )
         {
@@ -43,8 +39,8 @@ public sealed class IntegerConditionalBinaryOperatorConvolutionCalculator : IInt
             return null;
         }
 
-        var convolutedLeft = ConvolutionEvaluator.Evaluate( exprLeft,   0 );
-        var convolutedRight = ConvolutionEvaluator.Evaluate( exprRight, 0 );
+        var convolutedLeft = ConvolutionEvaluator.Evaluate( visitor, exprLeft,   0 );
+        var convolutedRight = ConvolutionEvaluator.Evaluate( visitor, exprRight, 0 );
 
         if( convolutedLeft == null || convolutedRight == null )
         {

--- a/Compiler/Domain/Ast/Analyzers/Evaluators/Convolutions/Conditions/RealConditionalBinaryOperatorConvolutionCalculator.cs
+++ b/Compiler/Domain/Ast/Analyzers/Evaluators/Convolutions/Conditions/RealConditionalBinaryOperatorConvolutionCalculator.cs
@@ -11,26 +11,23 @@ namespace KSPCompiler.Domain.Ast.Analyzers.Evaluators.Convolutions.Conditions;
 /// </summary>
 public sealed class RealConditionalBinaryOperatorConvolutionCalculator : IRealConditionalBinaryOperatorConvolutionCalculator
 {
-    private IAstVisitor Visitor { get; }
     private IRealConvolutionEvaluator ConvolutionEvaluator { get; }
 
     public RealConditionalBinaryOperatorConvolutionCalculator(
-        IAstVisitor visitor,
         IRealConvolutionEvaluator convolutionEvaluator )
     {
-        Visitor              = visitor;
         ConvolutionEvaluator = convolutionEvaluator;
     }
 
-    public bool? Calculate( AstExpressionNode expr )
+    public bool? Calculate( IAstVisitor visitor, AstExpressionNode expr )
     {
         if( expr.ChildNodeCount != 2 )
         {
             throw new ArgumentException( $"Expected 2 child nodes, but got {expr.ChildNodeCount}. (node: {expr.GetType().Name})" );
         }
 
-        var exprLeft = expr.Left.Accept( Visitor ) as AstExpressionNode;
-        var exprRight = expr.Right.Accept( Visitor ) as AstExpressionNode;
+        var exprLeft = expr.Left.Accept( visitor ) as AstExpressionNode;
+        var exprRight = expr.Right.Accept( visitor ) as AstExpressionNode;
 
         if( exprLeft == null || exprRight == null )
         {
@@ -43,8 +40,8 @@ public sealed class RealConditionalBinaryOperatorConvolutionCalculator : IRealCo
             return null;
         }
 
-        var convolutedLeft = ConvolutionEvaluator.Evaluate( exprLeft,   0 );
-        var convolutedRight = ConvolutionEvaluator.Evaluate( exprRight, 0 );
+        var convolutedLeft = ConvolutionEvaluator.Evaluate( visitor, exprLeft,   0 );
+        var convolutedRight = ConvolutionEvaluator.Evaluate( visitor, exprRight, 0 );
 
         if( convolutedLeft == null || convolutedRight == null )
         {

--- a/Compiler/Domain/Ast/Analyzers/Evaluators/Convolutions/IConditionalConvolutionCalculator.cs
+++ b/Compiler/Domain/Ast/Analyzers/Evaluators/Convolutions/IConditionalConvolutionCalculator.cs
@@ -10,7 +10,8 @@ public interface IConditionalConvolutionCalculator
     /// <summary>
     /// Calculate conditional expression
     /// </summary>
+    /// <param name="visitor">Visitor for traversing the AST</param>
     /// <param name="expr">Expression node</param>
     /// <returns>Evaluated value. If constant value is not found, returns null.</returns>
-    bool? Calculate( AstExpressionNode expr );
+    bool? Calculate( IAstVisitor visitor, AstExpressionNode expr );
 }

--- a/Compiler/Domain/Ast/Analyzers/Evaluators/Convolutions/IObjectConvolutionCalculator.cs
+++ b/Compiler/Domain/Ast/Analyzers/Evaluators/Convolutions/IObjectConvolutionCalculator.cs
@@ -11,8 +11,9 @@ public interface IObjectConvolutionCalculator<T> where T : class
     /// <summary>
     /// Calculate the value of the expression
     /// </summary>
+    /// <param name="visitor">Visitor for traversing the AST</param>
     /// <param name="expr">Expression node</param>
     /// <param name="workingValueForRecursive">Working value for recursive evaluation. First call should be default value of `T`.</param>
     /// <returns>Calculated value. If constant value is not found, returns null.</returns>
-    T? Calculate( AstExpressionNode expr, T workingValueForRecursive );
+    T? Calculate( IAstVisitor visitor, AstExpressionNode expr, T workingValueForRecursive );
 }

--- a/Compiler/Domain/Ast/Analyzers/Evaluators/Convolutions/IObjectConvolutionEvaluator.cs
+++ b/Compiler/Domain/Ast/Analyzers/Evaluators/Convolutions/IObjectConvolutionEvaluator.cs
@@ -10,8 +10,9 @@ public interface IObjectConvolutionEvaluator<T> where T : class
     /// <summary>
     /// Evaluate expression node
     /// </summary>
+    /// <param name="visitor">Visitor for traversing the AST</param>
     /// <param name="expr">Expression node</param>
     /// <param name="workingValueForRecursive">Working value for recursive evaluation. First call should be default value of T</param>
     /// <returns>Evaluated value. If constant value is not found, returns null.</returns>
-    T? Evaluate( AstExpressionNode expr, T workingValueForRecursive );
+    T? Evaluate( IAstVisitor visitor, AstExpressionNode expr, T workingValueForRecursive );
 }

--- a/Compiler/Domain/Ast/Analyzers/Evaluators/Convolutions/IPrimitiveConstantConvolutionCalculator.cs
+++ b/Compiler/Domain/Ast/Analyzers/Evaluators/Convolutions/IPrimitiveConstantConvolutionCalculator.cs
@@ -1,5 +1,3 @@
-using KSPCompiler.Domain.Ast.Nodes;
-
 namespace KSPCompiler.Domain.Ast.Analyzers.Evaluators.Convolutions;
 
 /// <summary>
@@ -7,9 +5,3 @@ namespace KSPCompiler.Domain.Ast.Analyzers.Evaluators.Convolutions;
 /// </summary>
 /// <typeparam name="T"></typeparam>
 public interface IPrimitiveConstantConvolutionCalculator<T> : IPrimitiveConvolutionCalculator<T> where T : struct {}
-
-public sealed class NullConstantConvolutionCalculator<T> : IPrimitiveConvolutionCalculator<T> where T : struct
-{
-    public T? Calculate( AstExpressionNode expr, T workingValueForRecursive )
-        => null;
-}

--- a/Compiler/Domain/Ast/Analyzers/Evaluators/Convolutions/IPrimitiveConvolutionBinaryCalculator.cs
+++ b/Compiler/Domain/Ast/Analyzers/Evaluators/Convolutions/IPrimitiveConvolutionBinaryCalculator.cs
@@ -10,6 +10,6 @@ public interface IPrimitiveConvolutionBinaryCalculator<T> : IPrimitiveConvolutio
 
 public sealed class NullConvolutionBinaryCalculator<T> : IPrimitiveConvolutionCalculator<T> where T : struct
 {
-    public T? Calculate( AstExpressionNode expr, T workingValueForRecursive )
+    public T? Calculate( IAstVisitor visitor, AstExpressionNode expr, T workingValueForRecursive )
         => null;
 }

--- a/Compiler/Domain/Ast/Analyzers/Evaluators/Convolutions/IPrimitiveConvolutionCalculator.cs
+++ b/Compiler/Domain/Ast/Analyzers/Evaluators/Convolutions/IPrimitiveConvolutionCalculator.cs
@@ -11,8 +11,9 @@ public interface IPrimitiveConvolutionCalculator<T> where T : struct
     /// <summary>
     /// Calculate the value of the expression
     /// </summary>
+    /// <param name="visitor">Visitor for traversing the AST</param>
     /// <param name="expr">Expression node</param>
     /// <param name="workingValueForRecursive">Working value for recursive evaluation. First call should be default value of `T`.</param>
     /// <returns>Calculated value. If constant value is not found, returns null.</returns>
-    T? Calculate( AstExpressionNode expr, T workingValueForRecursive );
+    T? Calculate( IAstVisitor visitor, AstExpressionNode expr, T workingValueForRecursive );
 }

--- a/Compiler/Domain/Ast/Analyzers/Evaluators/Convolutions/IPrimitiveConvolutionEvaluator.cs
+++ b/Compiler/Domain/Ast/Analyzers/Evaluators/Convolutions/IPrimitiveConvolutionEvaluator.cs
@@ -10,8 +10,9 @@ public interface IPrimitiveConvolutionEvaluator<T> where T : struct
     /// <summary>
     /// Evaluate expression node
     /// </summary>
+    /// <param name="visitor">Visitor for traversing the AST</param>
     /// <param name="expr">Expression node</param>
     /// <param name="workingValueForRecursive">Working value for recursive evaluation. First call should be default value of T</param>
     /// <returns>Evaluated value. If constant value is not found, returns null.</returns>
-    T? Evaluate( AstExpressionNode expr, T workingValueForRecursive );
+    T? Evaluate( IAstVisitor visitor, AstExpressionNode expr, T workingValueForRecursive );
 }

--- a/Compiler/Domain/Ast/Analyzers/Evaluators/Convolutions/IPrimitiveConvolutionUnaryCalculator.cs
+++ b/Compiler/Domain/Ast/Analyzers/Evaluators/Convolutions/IPrimitiveConvolutionUnaryCalculator.cs
@@ -10,6 +10,6 @@ public interface IPrimitiveConvolutionUnaryCalculator<T> : IPrimitiveConvolution
 
 public sealed class  NullConvolutionUnaryCalculator<T> : IPrimitiveConvolutionCalculator<T> where T : struct
 {
-    public T? Calculate( AstExpressionNode expr, T workingValueForRecursive )
+    public T? Calculate( IAstVisitor visitor, AstExpressionNode expr, T workingValueForRecursive )
         => null;
 }

--- a/Compiler/Domain/Ast/Analyzers/Evaluators/Convolutions/Integers/IntegerBinaryOperatorConvolutionCalculator.cs
+++ b/Compiler/Domain/Ast/Analyzers/Evaluators/Convolutions/Integers/IntegerBinaryOperatorConvolutionCalculator.cs
@@ -16,20 +16,20 @@ public sealed class IntegerBinaryOperatorConvolutionCalculator : IIntegerBinaryO
         EvaluatorForRecursive = evaluatorForRecursive;
     }
 
-    public int? Calculate( AstExpressionNode expr, int workingValueForRecursive )
+    public int? Calculate( IAstVisitor visitor, AstExpressionNode expr, int workingValueForRecursive )
     {
         if( expr.ChildNodeCount != 2 )
         {
             throw new ArgumentException( $"Expected 2 child nodes, but got {expr.ChildNodeCount}. (node: {expr.GetType().Name})" );
         }
 
-        var leftValue = EvaluatorForRecursive.Evaluate( expr.Left, workingValueForRecursive );
+        var leftValue = EvaluatorForRecursive.Evaluate( visitor, expr.Left, workingValueForRecursive );
         if( leftValue == null )
         {
             return null;
         }
 
-        var rightValue = EvaluatorForRecursive.Evaluate( expr.Right, workingValueForRecursive );
+        var rightValue = EvaluatorForRecursive.Evaluate( visitor, expr.Right, workingValueForRecursive );
         if( rightValue == null )
         {
             return null;

--- a/Compiler/Domain/Ast/Analyzers/Evaluators/Convolutions/Integers/IntegerConstantConvolutionCalculator.cs
+++ b/Compiler/Domain/Ast/Analyzers/Evaluators/Convolutions/Integers/IntegerConstantConvolutionCalculator.cs
@@ -27,7 +27,7 @@ public sealed class IntegerConstantConvolutionCalculator : IIntegerConstantConvo
         CompilerMessageManger = compilerMessageManger;
     }
 
-    public int? Calculate( AstExpressionNode expr, int workingValueForRecursive )
+    public int? Calculate( IAstVisitor visitor, AstExpressionNode expr, int workingValueForRecursive )
     {
         if( expr.ChildNodeCount != 0 )
         {

--- a/Compiler/Domain/Ast/Analyzers/Evaluators/Convolutions/Integers/IntegerConvolutionEvaluator.cs
+++ b/Compiler/Domain/Ast/Analyzers/Evaluators/Convolutions/Integers/IntegerConvolutionEvaluator.cs
@@ -20,13 +20,13 @@ public sealed class IntegerConvolutionEvaluator : IIntegerConvolutionEvaluator
         UnaryCalculator      = new IntegerUnaryOperatorConvolutionCalculator( this );
     }
 
-    public int? Evaluate( AstExpressionNode expr, int workingValueForRecursive )
+    public int? Evaluate( IAstVisitor visitor, AstExpressionNode expr, int workingValueForRecursive )
     {
         return expr.ChildNodeCount switch
         {
-            0 => ConstantCalculator.Calculate( expr, workingValueForRecursive ),
-            1 => UnaryCalculator.Calculate( expr, workingValueForRecursive ),
-            2 => BinaryCalculator.Calculate( expr, workingValueForRecursive ),
+            0 => ConstantCalculator.Calculate( visitor, expr, workingValueForRecursive ),
+            1 => UnaryCalculator.Calculate( visitor, expr, workingValueForRecursive ),
+            2 => BinaryCalculator.Calculate( visitor, expr, workingValueForRecursive ),
             _ => null
         };
     }

--- a/Compiler/Domain/Ast/Analyzers/Evaluators/Convolutions/Integers/IntegerUnaryOperatorConvolutionCalculator.cs
+++ b/Compiler/Domain/Ast/Analyzers/Evaluators/Convolutions/Integers/IntegerUnaryOperatorConvolutionCalculator.cs
@@ -16,14 +16,14 @@ public sealed class IntegerUnaryOperatorConvolutionCalculator : IIntegerUnaryOpe
         EvaluatorForRecursive = evaluatorForRecursive;
     }
 
-    public int? Calculate( AstExpressionNode expr, int workingValueForRecursive )
+    public int? Calculate( IAstVisitor visitor, AstExpressionNode expr, int workingValueForRecursive )
     {
         if( expr.ChildNodeCount != 1 )
         {
             throw new ArgumentException( $"Expected 1 child node, but got {expr.ChildNodeCount}. (node: {expr.GetType().Name})" );
         }
 
-        var convolutedValue = EvaluatorForRecursive.Evaluate( expr.Left, workingValueForRecursive );
+        var convolutedValue = EvaluatorForRecursive.Evaluate( visitor, expr.Left, workingValueForRecursive );
 
         if( convolutedValue == null )
         {

--- a/Compiler/Domain/Ast/Analyzers/Evaluators/Convolutions/Reals/RealBinaryOperatorConvolutionCalculator.cs
+++ b/Compiler/Domain/Ast/Analyzers/Evaluators/Convolutions/Reals/RealBinaryOperatorConvolutionCalculator.cs
@@ -16,20 +16,20 @@ public sealed class RealBinaryOperatorConvolutionCalculator : IRealBinaryOperato
         EvaluatorForRecursive = evaluatorForRecursive;
     }
 
-    public double? Calculate( AstExpressionNode expr, double workingValueForRecursive )
+    public double? Calculate( IAstVisitor visitor, AstExpressionNode expr, double workingValueForRecursive )
     {
         if( expr.ChildNodeCount != 2 )
         {
             throw new ArgumentException( $"Expected 2 child nodes, but got {expr.ChildNodeCount}. (node: {expr.GetType().Name})" );
         }
 
-        var leftValue = EvaluatorForRecursive.Evaluate( expr.Left, workingValueForRecursive );
+        var leftValue = EvaluatorForRecursive.Evaluate( visitor, expr.Left, workingValueForRecursive );
         if( leftValue == null )
         {
             return null;
         }
 
-        var rightValue = EvaluatorForRecursive.Evaluate( expr.Right, workingValueForRecursive );
+        var rightValue = EvaluatorForRecursive.Evaluate( visitor, expr.Right, workingValueForRecursive );
         if( rightValue == null )
         {
             return null;

--- a/Compiler/Domain/Ast/Analyzers/Evaluators/Convolutions/Reals/RealConstantConvolutionCalculator.cs
+++ b/Compiler/Domain/Ast/Analyzers/Evaluators/Convolutions/Reals/RealConstantConvolutionCalculator.cs
@@ -27,7 +27,7 @@ public sealed class RealConstantConvolutionCalculator : IRealConstantConvolution
         CompilerMessageManger = compilerMessageManger;
     }
 
-    public double? Calculate( AstExpressionNode expr, double _ )
+    public double? Calculate( IAstVisitor visitor, AstExpressionNode expr, double _ )
     {
         if( expr.ChildNodeCount != 0 )
         {

--- a/Compiler/Domain/Ast/Analyzers/Evaluators/Convolutions/Reals/RealConvolutionEvaluator.cs
+++ b/Compiler/Domain/Ast/Analyzers/Evaluators/Convolutions/Reals/RealConvolutionEvaluator.cs
@@ -20,13 +20,13 @@ public sealed class RealConvolutionEvaluator : IRealConvolutionEvaluator
         UnaryCalculator      = new RealUnaryOperatorConvolutionCalculator( this );
     }
 
-    public double? Evaluate( AstExpressionNode expr, double workingValueForRecursive )
+    public double? Evaluate( IAstVisitor visitor, AstExpressionNode expr, double workingValueForRecursive )
     {
         return expr.ChildNodeCount switch
         {
-            0 => ConstantCalculator.Calculate( expr, workingValueForRecursive ),
-            1 => UnaryCalculator.Calculate( expr, workingValueForRecursive ),
-            2 => BinaryCalculator.Calculate( expr, workingValueForRecursive ),
+            0 => ConstantCalculator.Calculate( visitor, expr, workingValueForRecursive ),
+            1 => UnaryCalculator.Calculate( visitor, expr, workingValueForRecursive ),
+            2 => BinaryCalculator.Calculate( visitor, expr, workingValueForRecursive ),
             _ => null
         };
     }

--- a/Compiler/Domain/Ast/Analyzers/Evaluators/Convolutions/Reals/RealUnaryOperatorConvolutionCalculator.cs
+++ b/Compiler/Domain/Ast/Analyzers/Evaluators/Convolutions/Reals/RealUnaryOperatorConvolutionCalculator.cs
@@ -16,14 +16,14 @@ public sealed class RealUnaryOperatorConvolutionCalculator : IRealUnaryOperatorC
         EvaluatorForRecursive = evaluatorForRecursive;
     }
 
-    public double? Calculate( AstExpressionNode expr, double workingValueForRecursive )
+    public double? Calculate( IAstVisitor visitor, AstExpressionNode expr, double workingValueForRecursive )
     {
         if( expr.ChildNodeCount != 1 )
         {
             throw new ArgumentException( $"Expected 1 child node, but got {expr.ChildNodeCount}. (node: {expr.GetType().Name})" );
         }
 
-        var convolutedValue = EvaluatorForRecursive.Evaluate( expr.Left, workingValueForRecursive );
+        var convolutedValue = EvaluatorForRecursive.Evaluate( visitor, expr.Left, workingValueForRecursive );
 
         if( convolutedValue == null )
         {

--- a/Compiler/Domain/Ast/Analyzers/Evaluators/Convolutions/Strings/StringConcatenateOperatorConvolutionCalculator.cs
+++ b/Compiler/Domain/Ast/Analyzers/Evaluators/Convolutions/Strings/StringConcatenateOperatorConvolutionCalculator.cs
@@ -16,20 +16,20 @@ public sealed class StringConcatenateOperatorConvolutionCalculator : IStringConc
         EvaluatorForRecursive = evaluatorForRecursive;
     }
 
-    public string? Calculate( AstExpressionNode expr, string workingValueForRecursive )
+    public string? Calculate( IAstVisitor visitor, AstExpressionNode expr, string workingValueForRecursive )
     {
         if( expr.ChildNodeCount != 2 )
         {
             throw new ArgumentException( $"Expected 2 child nodes, but got {expr.ChildNodeCount}. (node: {expr.GetType().Name})" );
         }
 
-        var leftValue = EvaluatorForRecursive.Evaluate( expr.Left, workingValueForRecursive );
+        var leftValue = EvaluatorForRecursive.Evaluate( visitor, expr.Left, workingValueForRecursive );
         if( leftValue == null )
         {
             return null;
         }
 
-        var rightValue = EvaluatorForRecursive.Evaluate( expr.Right, workingValueForRecursive );
+        var rightValue = EvaluatorForRecursive.Evaluate( visitor, expr.Right, workingValueForRecursive );
         if( rightValue == null )
         {
             return null;

--- a/Compiler/Domain/Ast/Analyzers/Evaluators/Convolutions/Strings/StringConstantConvolutionCalculator.cs
+++ b/Compiler/Domain/Ast/Analyzers/Evaluators/Convolutions/Strings/StringConstantConvolutionCalculator.cs
@@ -27,7 +27,7 @@ public sealed class StringConstantConvolutionCalculator : IStringConstantConvolu
         VariableSymbols       = variableSymbols;
         CompilerMessageManger = compilerMessageManger;
     }
-    public string? Calculate( AstExpressionNode expr, string _ )
+    public string? Calculate( IAstVisitor visitor, AstExpressionNode expr, string _ )
     {
         if( expr.ChildNodeCount != 0 )
         {

--- a/Compiler/Domain/Ast/Analyzers/Evaluators/Convolutions/Strings/StringConvolutionEvaluator.cs
+++ b/Compiler/Domain/Ast/Analyzers/Evaluators/Convolutions/Strings/StringConvolutionEvaluator.cs
@@ -18,12 +18,12 @@ public sealed class StringConvolutionEvaluator : IStringConvolutionEvaluator
         ConcatenateCalculator = new StringConcatenateOperatorConvolutionCalculator( this );
     }
 
-    public string? Evaluate( AstExpressionNode expr, string workingValueForRecursive )
+    public string? Evaluate( IAstVisitor visitor, AstExpressionNode expr, string workingValueForRecursive )
     {
         return expr.ChildNodeCount switch
         {
-            0 => ConstantCalculator.Calculate( expr, workingValueForRecursive ),
-            2 => ConcatenateCalculator.Calculate( expr, workingValueForRecursive ),
+            0 => ConstantCalculator.Calculate( visitor, expr, workingValueForRecursive ),
+            2 => ConcatenateCalculator.Calculate( visitor, expr, workingValueForRecursive ),
             _ => null
         };
     }

--- a/Compiler/Domain/Ast/Analyzers/Evaluators/Operators/IAssignOperatorEvaluator.cs
+++ b/Compiler/Domain/Ast/Analyzers/Evaluators/Operators/IAssignOperatorEvaluator.cs
@@ -1,5 +1,3 @@
-using KSPCompiler.Domain.Ast.Nodes;
-
 namespace KSPCompiler.Domain.Ast.Analyzers.Evaluators.Operators;
 
-public interface IAssignOperatorEvaluator : IOperatorEvaluator<IAstNode> {}
+public interface IAssignOperatorEvaluator : IOperatorEvaluator {}

--- a/Compiler/Domain/Ast/Analyzers/Evaluators/Operators/IBinaryOperatorEvaluator.cs
+++ b/Compiler/Domain/Ast/Analyzers/Evaluators/Operators/IBinaryOperatorEvaluator.cs
@@ -1,5 +1,3 @@
-using KSPCompiler.Domain.Ast.Nodes;
-
 namespace KSPCompiler.Domain.Ast.Analyzers.Evaluators.Operators;
 
-public interface IBinaryOperatorEvaluator : IOperatorEvaluator<IAstNode> {}
+public interface IBinaryOperatorEvaluator : IOperatorEvaluator {}

--- a/Compiler/Domain/Ast/Analyzers/Evaluators/Operators/IOperatorEvaluator.cs
+++ b/Compiler/Domain/Ast/Analyzers/Evaluators/Operators/IOperatorEvaluator.cs
@@ -2,7 +2,7 @@ using KSPCompiler.Domain.Ast.Nodes;
 
 namespace KSPCompiler.Domain.Ast.Analyzers.Evaluators.Operators;
 
-public interface IOperatorEvaluator<TEvalResult>
+public interface IOperatorEvaluator
 {
-    public TEvalResult Evaluate( IAstVisitor<TEvalResult> visitor, AstExpressionNode expr );
+    public IAstNode Evaluate( IAstVisitor visitor, AstExpressionNode expr );
 }

--- a/Compiler/Domain/Ast/Analyzers/Evaluators/Operators/IStringConcatenateOperatorEvaluator.cs
+++ b/Compiler/Domain/Ast/Analyzers/Evaluators/Operators/IStringConcatenateOperatorEvaluator.cs
@@ -1,5 +1,3 @@
-using KSPCompiler.Domain.Ast.Nodes;
-
 namespace KSPCompiler.Domain.Ast.Analyzers.Evaluators.Operators;
 
-public interface IStringConcatenateOperatorEvaluator : IOperatorEvaluator<IAstNode> {}
+public interface IStringConcatenateOperatorEvaluator : IOperatorEvaluator {}

--- a/Compiler/Domain/Ast/Analyzers/Evaluators/Operators/IUnaryOperatorEvaluator.cs
+++ b/Compiler/Domain/Ast/Analyzers/Evaluators/Operators/IUnaryOperatorEvaluator.cs
@@ -1,5 +1,3 @@
-using KSPCompiler.Domain.Ast.Nodes;
-
 namespace KSPCompiler.Domain.Ast.Analyzers.Evaluators.Operators;
 
-public interface IUnaryOperatorEvaluator : IOperatorEvaluator<IAstNode> {}
+public interface IUnaryOperatorEvaluator : IOperatorEvaluator {}

--- a/Compiler/Domain/Ast/Analyzers/Evaluators/Symbols/IArrayElementEvaluator.cs
+++ b/Compiler/Domain/Ast/Analyzers/Evaluators/Symbols/IArrayElementEvaluator.cs
@@ -3,9 +3,7 @@ using KSPCompiler.Domain.Ast.Nodes.Expressions;
 
 namespace KSPCompiler.Domain.Ast.Analyzers.Evaluators.Symbols;
 
-public interface IArrayElementEvaluator<TEvalResult>
+public interface IArrayElementEvaluator
 {
-    public TEvalResult Evaluate( IAstVisitor<TEvalResult> visitor, AstArrayElementExpressionNode expr );
+    public IAstNode Evaluate( IAstVisitor visitor, AstArrayElementExpressionNode expr );
 }
-
-public interface IArrayElementEvaluator : IArrayElementEvaluator<IAstNode> {}

--- a/Compiler/Domain/Ast/Analyzers/Evaluators/Symbols/ISymbolEvaluator.cs
+++ b/Compiler/Domain/Ast/Analyzers/Evaluators/Symbols/ISymbolEvaluator.cs
@@ -3,9 +3,7 @@ using KSPCompiler.Domain.Ast.Nodes.Expressions;
 
 namespace KSPCompiler.Domain.Ast.Analyzers.Evaluators.Symbols;
 
-public interface ISymbolEvaluator<TEvalResult>
+public interface ISymbolEvaluator
 {
-    public TEvalResult Evaluate( IAstVisitor<TEvalResult> visitor, AstSymbolExpressionNode expr );
+    public IAstNode Evaluate( IAstVisitor visitor, AstSymbolExpressionNode expr );
 }
-
-public interface ISymbolEvaluator : ISymbolEvaluator<IAstNode> {}

--- a/Compiler/Domain/Ast/Analyzers/Semantics/ArrayElementEvaluator.cs
+++ b/Compiler/Domain/Ast/Analyzers/Semantics/ArrayElementEvaluator.cs
@@ -20,7 +20,7 @@ public class ArrayElementEvaluator : IArrayElementEvaluator
         VariableSymbolTable   = variableSymbolTable;
     }
 
-    public IAstNode Evaluate( IAstVisitor<IAstNode> visitor, AstArrayElementExpressionNode expr )
+    public IAstNode Evaluate( IAstVisitor visitor, AstArrayElementExpressionNode expr )
     {
         /*
                symbol

--- a/Compiler/Domain/Ast/Analyzers/Semantics/AssignOperatorEvaluator.cs
+++ b/Compiler/Domain/Ast/Analyzers/Semantics/AssignOperatorEvaluator.cs
@@ -1,7 +1,6 @@
 using KSPCompiler.Domain.Ast.Analyzers.Evaluators.Operators;
 using KSPCompiler.Domain.Ast.Extensions;
 using KSPCompiler.Domain.Ast.Nodes;
-using KSPCompiler.Domain.Ast.Nodes.Expressions;
 using KSPCompiler.Domain.CompilerMessages;
 using KSPCompiler.Domain.Symbols.MetaData;
 using KSPCompiler.Domain.Symbols.MetaData.Extensions;
@@ -26,7 +25,7 @@ public sealed class AssignOperatorEvaluator : IAssignOperatorEvaluator
         CompilerMessageManger = compilerMessageManger;
     }
 
-    public IAstNode Evaluate( IAstVisitor<IAstNode> visitor, AstExpressionNode expr )
+    public IAstNode Evaluate( IAstVisitor visitor, AstExpressionNode expr )
     {
         /*
                      := expr

--- a/Compiler/Domain/Ast/Analyzers/Semantics/CallCommandExpressionEvaluator.cs
+++ b/Compiler/Domain/Ast/Analyzers/Semantics/CallCommandExpressionEvaluator.cs
@@ -22,7 +22,7 @@ public class CallCommandExpressionEvaluator : ICallCommandExpressionEvaluator
         Commands              = commands;
     }
 
-    public IAstNode Evaluate( IAstVisitor<IAstNode> visitor, AstCallCommandExpressionNode expr )
+    public IAstNode Evaluate( IAstVisitor visitor, AstCallCommandExpressionNode expr )
     {
         if( !TryGetCommandSymbol( visitor, expr, out var commandSymbol ) )
         {
@@ -40,7 +40,7 @@ public class CallCommandExpressionEvaluator : ICallCommandExpressionEvaluator
         return result;
     }
 
-    private bool TryGetCommandSymbol( IAstVisitor<IAstNode> visitor, AstCallCommandExpressionNode expr, out CommandSymbol result )
+    private bool TryGetCommandSymbol( IAstVisitor visitor, AstCallCommandExpressionNode expr, out CommandSymbol result )
     {
         result = default!;
 
@@ -65,7 +65,7 @@ public class CallCommandExpressionEvaluator : ICallCommandExpressionEvaluator
         return true;
     }
 
-    private bool ValidateCommandArguments( IAstVisitor<IAstNode> visitor, AstCallCommandExpressionNode expr, CommandSymbol commandSymbol )
+    private bool ValidateCommandArguments( IAstVisitor visitor, AstCallCommandExpressionNode expr, CommandSymbol commandSymbol )
     {
         if( expr.Right is not AstExpressionListNode arguments )
         {

--- a/Compiler/Domain/Ast/Analyzers/Semantics/ConditionalBinaryOperatorEvaluator.cs
+++ b/Compiler/Domain/Ast/Analyzers/Semantics/ConditionalBinaryOperatorEvaluator.cs
@@ -18,7 +18,7 @@ public class ConditionalBinaryOperatorEvaluator : IConditionalBinaryOperatorEval
         CompilerMessageManger = compilerMessageManger;
     }
 
-    public IAstNode Evaluate( IAstVisitor<IAstNode> visitor, AstExpressionNode expr )
+    public IAstNode Evaluate( IAstVisitor visitor, AstExpressionNode expr )
     {
         /*
                     operator

--- a/Compiler/Domain/Ast/Analyzers/Semantics/ConditionalLogicalOperatorEvaluator.cs
+++ b/Compiler/Domain/Ast/Analyzers/Semantics/ConditionalLogicalOperatorEvaluator.cs
@@ -24,7 +24,7 @@ public class ConditionalLogicalOperatorEvaluator : IConditionalLogicalOperatorEv
         BooleanConvolutionEvaluator = booleanConvolutionEvaluator;
     }
 
-    public IAstNode Evaluate( IAstVisitor<IAstNode> visitor, AstExpressionNode expr )
+    public IAstNode Evaluate( IAstVisitor visitor, AstExpressionNode expr )
     {
         /*
                     operator
@@ -66,7 +66,7 @@ public class ConditionalLogicalOperatorEvaluator : IConditionalLogicalOperatorEv
         }
 
         // リテラルに畳み込み可能なら畳み込む
-        if( TryConvolutionValue( expr, out var convolutedValue ) )
+        if( TryConvolutionValue( visitor, expr, out var convolutedValue ) )
         {
             return convolutedValue;
         }
@@ -77,11 +77,11 @@ public class ConditionalLogicalOperatorEvaluator : IConditionalLogicalOperatorEv
         return result;
     }
 
-    private bool TryConvolutionValue( AstExpressionNode expr, out AstExpressionNode convolutedValue )
+    private bool TryConvolutionValue( IAstVisitor visitor, AstExpressionNode expr, out AstExpressionNode convolutedValue )
     {
         convolutedValue = NullAstExpressionNode.Instance;
 
-        var result = BooleanConvolutionEvaluator.Evaluate( expr, false );
+        var result = BooleanConvolutionEvaluator.Evaluate( visitor, expr, false );
 
         if( result == null )
         {

--- a/Compiler/Domain/Ast/Analyzers/Semantics/ConditionalUnaryOperatorEvaluator.cs
+++ b/Compiler/Domain/Ast/Analyzers/Semantics/ConditionalUnaryOperatorEvaluator.cs
@@ -32,7 +32,7 @@ public class ConditionalUnaryOperatorEvaluator : IUnaryOperatorEvaluator
         BooleanConvolutionEvaluator = booleanConvolutionEvaluator;
     }
 
-    public IAstNode Evaluate( IAstVisitor<IAstNode> visitor, AstExpressionNode expr )
+    public IAstNode Evaluate( IAstVisitor visitor, AstExpressionNode expr )
     {
         /*
           <<logical unary not operator>>
@@ -65,7 +65,7 @@ public class ConditionalUnaryOperatorEvaluator : IUnaryOperatorEvaluator
         }
 
         // リテラルに畳み込み可能なら畳み込む
-        if( TryConvolutionValue( expr, out var convolutedValue ) )
+        if( TryConvolutionValue( visitor, expr, out var convolutedValue ) )
         {
             return convolutedValue;
         }
@@ -73,11 +73,11 @@ public class ConditionalUnaryOperatorEvaluator : IUnaryOperatorEvaluator
         return CreateEvaluateNode( expr, DataTypeFlag.TypeBool );
     }
 
-    private bool TryConvolutionValue( AstExpressionNode expr, out AstExpressionNode convolutedValue )
+    private bool TryConvolutionValue( IAstVisitor visitor, AstExpressionNode expr, out AstExpressionNode convolutedValue )
     {
         convolutedValue = NullAstExpressionNode.Instance;
 
-        var result = BooleanConvolutionEvaluator.Evaluate( expr, false );
+        var result = BooleanConvolutionEvaluator.Evaluate( visitor, expr, false );
 
         if( result == null )
         {

--- a/Compiler/Domain/Ast/Analyzers/Semantics/NumericBinaryOperatorEvaluator.cs
+++ b/Compiler/Domain/Ast/Analyzers/Semantics/NumericBinaryOperatorEvaluator.cs
@@ -14,7 +14,6 @@ namespace KSPCompiler.Domain.Ast.Analyzers.Semantics;
 
 public class NumericBinaryOperatorEvaluator : IBinaryOperatorEvaluator
 {
-    protected IAstVisitor AstVisitor { get; }
     protected ICompilerMessageManger CompilerMessageManger { get; }
     protected IIntegerConvolutionEvaluator IntegerConvolutionEvaluator { get; }
     protected IRealConvolutionEvaluator RealConvolutionEvaluator { get; }
@@ -28,18 +27,16 @@ public class NumericBinaryOperatorEvaluator : IBinaryOperatorEvaluator
     }
 
     public NumericBinaryOperatorEvaluator(
-        IAstVisitor astVisitor,
         ICompilerMessageManger compilerMessageManger,
         IIntegerConvolutionEvaluator integerConvolutionEvaluator,
         IRealConvolutionEvaluator realConvolutionEvaluator )
     {
-        AstVisitor                  = astVisitor;
         CompilerMessageManger       = compilerMessageManger;
         IntegerConvolutionEvaluator = integerConvolutionEvaluator;
         RealConvolutionEvaluator    = realConvolutionEvaluator;
     }
 
-    public IAstNode Evaluate( IAstVisitor<IAstNode> visitor, AstExpressionNode expr )
+    public IAstNode Evaluate( IAstVisitor visitor, AstExpressionNode expr )
     {
         /*
                 <<operator>> expr
@@ -75,7 +72,7 @@ public class NumericBinaryOperatorEvaluator : IBinaryOperatorEvaluator
         }
 
         // 左辺、右辺共にリテラル、定数なら畳み込み
-        if( TryConvolutionValue( expr, evaluatedLeft, evaluatedRight, resultType, out var convolutedValue ) )
+        if( TryConvolutionValue( visitor, expr, evaluatedLeft, evaluatedRight, resultType, out var convolutedValue ) )
         {
             return convolutedValue;
         }
@@ -83,7 +80,7 @@ public class NumericBinaryOperatorEvaluator : IBinaryOperatorEvaluator
         return CreateEvaluateNode( expr, resultType );
     }
 
-    private bool TryConvolutionValue( AstExpressionNode expr, AstExpressionNode left, AstExpressionNode right, DataTypeFlag resultType, out AstExpressionNode convolutedValue )
+    private bool TryConvolutionValue( IAstVisitor visitor, AstExpressionNode expr, AstExpressionNode left, AstExpressionNode right, DataTypeFlag resultType, out AstExpressionNode convolutedValue )
     {
         convolutedValue = default!;
 
@@ -96,7 +93,7 @@ public class NumericBinaryOperatorEvaluator : IBinaryOperatorEvaluator
 
         if( resultType.IsInt() )
         {
-            var convolutedInt = IntegerConvolutionEvaluator.Evaluate( expr, 0 );
+            var convolutedInt = IntegerConvolutionEvaluator.Evaluate( visitor, expr, 0 );
 
             if( convolutedInt == null )
             {
@@ -108,7 +105,7 @@ public class NumericBinaryOperatorEvaluator : IBinaryOperatorEvaluator
         }
         else if( resultType.IsReal() )
         {
-            var convolutedReal = RealConvolutionEvaluator.Evaluate( expr, 0 );
+            var convolutedReal = RealConvolutionEvaluator.Evaluate( visitor, expr, 0 );
 
             if( convolutedReal == null )
             {

--- a/Compiler/Domain/Ast/Analyzers/Semantics/NumericUnrayOperatorEvaluator.cs
+++ b/Compiler/Domain/Ast/Analyzers/Semantics/NumericUnrayOperatorEvaluator.cs
@@ -14,7 +14,6 @@ namespace KSPCompiler.Domain.Ast.Analyzers.Semantics;
 
 public sealed class NumericUnaryOperatorEvaluator : IUnaryOperatorEvaluator
 {
-    private IAstVisitor AstVisitor { get; }
     private ICompilerMessageManger CompilerMessageManger { get; }
     private IIntegerConvolutionEvaluator IntegerConvolutionEvaluator { get; }
     private IRealConvolutionEvaluator RealConvolutionEvaluator { get; }
@@ -28,18 +27,16 @@ public sealed class NumericUnaryOperatorEvaluator : IUnaryOperatorEvaluator
     }
 
     public NumericUnaryOperatorEvaluator(
-        IAstVisitor astVisitor,
         ICompilerMessageManger compilerMessageManger,
         IIntegerConvolutionEvaluator integerConvolutionEvaluator,
         IRealConvolutionEvaluator realConvolutionEvaluator )
     {
-        AstVisitor                  = astVisitor;
         CompilerMessageManger       = compilerMessageManger;
         IntegerConvolutionEvaluator = integerConvolutionEvaluator;
         RealConvolutionEvaluator    = realConvolutionEvaluator;
     }
 
-    public IAstNode Evaluate( IAstVisitor<IAstNode> visitor, AstExpressionNode expr )
+    public IAstNode Evaluate( IAstVisitor visitor, AstExpressionNode expr )
     {
         /*
               <<operator>> expr
@@ -72,7 +69,7 @@ public sealed class NumericUnaryOperatorEvaluator : IUnaryOperatorEvaluator
         }
 
         // リテラル、定数なら畳み込み
-        if( TryConvolutionValue( expr, evaluatedLeft, resultType, out var convolutedValue ) )
+        if( TryConvolutionValue( visitor, expr, evaluatedLeft, resultType, out var convolutedValue ) )
         {
             return convolutedValue;
         }
@@ -80,7 +77,7 @@ public sealed class NumericUnaryOperatorEvaluator : IUnaryOperatorEvaluator
         return CreateEvaluateNode( expr, resultType );
     }
 
-    private bool TryConvolutionValue( AstExpressionNode expr, AstExpressionNode left, DataTypeFlag resultType, out AstExpressionNode convolutedValue )
+    private bool TryConvolutionValue( IAstVisitor visitor, AstExpressionNode expr, AstExpressionNode left, DataTypeFlag resultType, out AstExpressionNode convolutedValue )
     {
         convolutedValue = default!;
 
@@ -93,7 +90,7 @@ public sealed class NumericUnaryOperatorEvaluator : IUnaryOperatorEvaluator
 
         if( resultType.IsInt() )
         {
-            var convolutedInt = IntegerConvolutionEvaluator.Evaluate( expr, 0 );
+            var convolutedInt = IntegerConvolutionEvaluator.Evaluate( visitor, expr, 0 );
 
             if( convolutedInt == null )
             {
@@ -105,7 +102,7 @@ public sealed class NumericUnaryOperatorEvaluator : IUnaryOperatorEvaluator
         }
         else if( resultType.IsReal() )
         {
-            var convolutedReal = RealConvolutionEvaluator.Evaluate( expr, 0 );
+            var convolutedReal = RealConvolutionEvaluator.Evaluate( visitor, expr, 0 );
 
             if( convolutedReal == null )
             {

--- a/Compiler/Domain/Ast/Analyzers/Semantics/SemanticAnalyzer.cs
+++ b/Compiler/Domain/Ast/Analyzers/Semantics/SemanticAnalyzer.cs
@@ -68,9 +68,9 @@ public partial class SemanticAnalyzer : DefaultAstVisitor, IAstTraversal
         RealConvolutionEvaluator    = new RealConvolutionEvaluator( this, SymbolTable.Variables, CompilerMessageManger );
         StringConvolutionEvaluator  = new StringConvolutionEvaluator( this, SymbolTable.Variables, CompilerMessageManger );
 
-        NumericBinaryOperatorEvaluator     = new NumericBinaryOperatorEvaluator( this, CompilerMessageManger, IntegerConvolutionEvaluator, RealConvolutionEvaluator );
-        NumericUnaryOperatorEvaluator      = new NumericUnaryOperatorEvaluator( this, CompilerMessageManger, IntegerConvolutionEvaluator, RealConvolutionEvaluator );
-        StringConcatenateOperatorEvaluator = new StringConcatenateOperatorEvaluator( this, CompilerMessageManger, StringConvolutionEvaluator );
+        NumericBinaryOperatorEvaluator     = new NumericBinaryOperatorEvaluator( CompilerMessageManger, IntegerConvolutionEvaluator, RealConvolutionEvaluator );
+        NumericUnaryOperatorEvaluator      = new NumericUnaryOperatorEvaluator( CompilerMessageManger, IntegerConvolutionEvaluator, RealConvolutionEvaluator );
+        StringConcatenateOperatorEvaluator = new StringConcatenateOperatorEvaluator( CompilerMessageManger, StringConvolutionEvaluator );
 
         SymbolEvaluator                    = new SymbolEvaluator( CompilerMessageManger, SymbolTable );
         AssignOperatorEvaluator            = new AssignOperatorEvaluator( CompilerMessageManger );

--- a/Compiler/Domain/Ast/Analyzers/Semantics/StringConcatenateOperatorEvaluator.cs
+++ b/Compiler/Domain/Ast/Analyzers/Semantics/StringConcatenateOperatorEvaluator.cs
@@ -13,7 +13,6 @@ namespace KSPCompiler.Domain.Ast.Analyzers.Semantics;
 
 public sealed class StringConcatenateOperatorEvaluator : IStringConcatenateOperatorEvaluator
 {
-    private IAstVisitor AstVisitor { get; }
     private ICompilerMessageManger CompilerMessageManger { get; }
     private IStringConvolutionEvaluator StringConvolutionEvaluator { get; }
 
@@ -26,16 +25,14 @@ public sealed class StringConcatenateOperatorEvaluator : IStringConcatenateOpera
     }
 
     public StringConcatenateOperatorEvaluator(
-        IAstVisitor astVisitor,
         ICompilerMessageManger compilerMessageManger,
         IStringConvolutionEvaluator stringConvolutionEvaluator )
     {
-        AstVisitor                 = astVisitor;
         CompilerMessageManger      = compilerMessageManger;
         StringConvolutionEvaluator = stringConvolutionEvaluator;
     }
 
-    public IAstNode Evaluate( IAstVisitor<IAstNode> visitor, AstExpressionNode expr )
+    public IAstNode Evaluate( IAstVisitor visitor, AstExpressionNode expr )
     {
         /*
                <<operator &>> expr
@@ -89,7 +86,7 @@ public sealed class StringConcatenateOperatorEvaluator : IStringConcatenateOpera
         }
 
         // 左辺、右辺共にリテラル、定数なら畳み込み
-        if( TryConvolutionValue( expr, evaluatedLeft, evaluatedRight, out var convolutedValue ) )
+        if( TryConvolutionValue( visitor, expr, evaluatedLeft, evaluatedRight, out var convolutedValue ) )
         {
             return convolutedValue;
         }
@@ -97,7 +94,7 @@ public sealed class StringConcatenateOperatorEvaluator : IStringConcatenateOpera
         return CreateEvaluateNode( expr, DataTypeFlag.TypeString );
     }
 
-    private bool TryConvolutionValue( AstExpressionNode expr, AstExpressionNode left, AstExpressionNode right, out AstExpressionNode convolutedNode )
+    private bool TryConvolutionValue( IAstVisitor visitor, AstExpressionNode expr, AstExpressionNode left, AstExpressionNode right, out AstExpressionNode convolutedNode )
     {
         convolutedNode = default!;
 
@@ -107,7 +104,7 @@ public sealed class StringConcatenateOperatorEvaluator : IStringConcatenateOpera
             return false;
         }
 
-        var convolutedValie = StringConvolutionEvaluator.Evaluate( expr, "" );
+        var convolutedValie = StringConvolutionEvaluator.Evaluate( visitor, expr, "" );
         if( convolutedValie == null )
         {
             return false;

--- a/Compiler/Domain/Ast/Analyzers/Semantics/SymbolEvaluator.cs
+++ b/Compiler/Domain/Ast/Analyzers/Semantics/SymbolEvaluator.cs
@@ -43,7 +43,7 @@ public class SymbolEvaluator : ISymbolEvaluator
         SymbolTable           = symbolTable;
     }
 
-    public IAstNode Evaluate( IAstVisitor<IAstNode> visitor, AstSymbolExpressionNode expr )
+    public IAstNode Evaluate( IAstVisitor visitor, AstSymbolExpressionNode expr )
     {
         if( TryGetVariableSymbol( visitor, expr, out var result ) )
         {
@@ -72,7 +72,7 @@ public class SymbolEvaluator : ISymbolEvaluator
         return result;
     }
 
-    private bool TryGetVariableSymbol( IAstVisitor<IAstNode> visitor, AstSymbolExpressionNode expr, out AstExpressionNode result )
+    private bool TryGetVariableSymbol( IAstVisitor visitor, AstSymbolExpressionNode expr, out AstExpressionNode result )
     {
         result = NullAstExpressionNode.Instance;
 
@@ -139,7 +139,7 @@ public class SymbolEvaluator : ISymbolEvaluator
         }
     }
 
-    private bool TryGetArrayVariableNode( IAstVisitor<IAstNode> visitor, AstExpressionNode expr, VariableSymbol variable, out AstExpressionNode result )
+    private bool TryGetArrayVariableNode( IAstVisitor visitor, AstExpressionNode expr, VariableSymbol variable, out AstExpressionNode result )
     {
         result = NullAstExpressionNode.Instance;
 

--- a/Compiler/Domain/Ast/Nodes/AstConditionalStatementNode.cs
+++ b/Compiler/Domain/Ast/Nodes/AstConditionalStatementNode.cs
@@ -34,7 +34,7 @@ namespace KSPCompiler.Domain.Ast.Nodes
         /// <summary>
         /// Call Condition, CodeBlock's <see cref="AcceptChildren{T}"/>
         /// </summary>
-        public override void AcceptChildren<T>( IAstVisitor<T> visitor )
+        public override void AcceptChildren( IAstVisitor visitor )
         {
             Condition.AcceptChildren( visitor );
             CodeBlock.AcceptChildren( visitor );

--- a/Compiler/Domain/Ast/Nodes/AstExpressionNode.cs
+++ b/Compiler/Domain/Ast/Nodes/AstExpressionNode.cs
@@ -103,7 +103,7 @@ namespace KSPCompiler.Domain.Ast.Nodes
         ///
         /// <inheritdoc/>
         ///
-        public override void AcceptChildren<T>( IAstVisitor<T> visitor )
+        public override void AcceptChildren( IAstVisitor visitor )
         {
             _ = Left.Accept( visitor );
             _ = Right.Accept( visitor );

--- a/Compiler/Domain/Ast/Nodes/AstFunctionalNode.cs
+++ b/Compiler/Domain/Ast/Nodes/AstFunctionalNode.cs
@@ -40,7 +40,7 @@ namespace KSPCompiler.Domain.Ast.Nodes
         ///
         /// <inheritdoc/>
         ///
-        public override void AcceptChildren<T>( IAstVisitor<T> visitor )
+        public override void AcceptChildren( IAstVisitor visitor )
         {
             Block.AcceptChildren( visitor );
         }

--- a/Compiler/Domain/Ast/Nodes/AstModiferNode.cs
+++ b/Compiler/Domain/Ast/Nodes/AstModiferNode.cs
@@ -36,10 +36,10 @@ namespace KSPCompiler.Domain.Ast.Nodes
 
         #region IAstNodeAcceptor
 
-        public override T Accept<T>( IAstVisitor<T> visitor )
+        public override IAstNode Accept( IAstVisitor visitor )
             => visitor.Visit( this );
 
-        public override void AcceptChildren<T>( IAstVisitor<T> visitor ) {}
+        public override void AcceptChildren( IAstVisitor visitor ) {}
 
         #endregion
     }

--- a/Compiler/Domain/Ast/Nodes/AstNode.cs
+++ b/Compiler/Domain/Ast/Nodes/AstNode.cs
@@ -72,12 +72,12 @@ namespace KSPCompiler.Domain.Ast.Nodes
         ///
         /// <inheritdoc/>
         ///
-        public abstract T Accept<T>( IAstVisitor<T> visitor );
+        public abstract IAstNode Accept( IAstVisitor visitor );
 
         ///
         /// <inheritdoc/>
         ///
-        public abstract void AcceptChildren<T>( IAstVisitor<T> visitor );
+        public abstract void AcceptChildren( IAstVisitor visitor );
         #endregion IAstNodeAcceptor
 
         #region IAstNode

--- a/Compiler/Domain/Ast/Nodes/Blocks/AstArgumentListNode.cs
+++ b/Compiler/Domain/Ast/Nodes/Blocks/AstArgumentListNode.cs
@@ -41,13 +41,13 @@ namespace KSPCompiler.Domain.Ast.Nodes.Blocks
         ///
         /// <inheritdoc/>
         ///
-        public override T Accept<T>( IAstVisitor<T> visitor )
+        public override IAstNode Accept( IAstVisitor visitor )
             => visitor.Visit( this );
 
         ///
         /// <inheritdoc/>
         ///
-        public override void AcceptChildren<T>( IAstVisitor<T> visitor )
+        public override void AcceptChildren( IAstVisitor visitor )
         {
             // Do nothing
         }

--- a/Compiler/Domain/Ast/Nodes/Blocks/AstArgumentNode.cs
+++ b/Compiler/Domain/Ast/Nodes/Blocks/AstArgumentNode.cs
@@ -37,12 +37,12 @@ namespace KSPCompiler.Domain.Ast.Nodes.Blocks
         ///
         /// <inheritdoc/>
         ///
-        public override T Accept<T>( IAstVisitor<T> visitor )
+        public override IAstNode Accept( IAstVisitor visitor )
         {
             return visitor.Visit( this );
         }
 
-        public override void AcceptChildren<T>( IAstVisitor<T> visitor )
+        public override void AcceptChildren( IAstVisitor visitor )
         {
             // Do nothing
         }

--- a/Compiler/Domain/Ast/Nodes/Blocks/AstBlockNode.cs
+++ b/Compiler/Domain/Ast/Nodes/Blocks/AstBlockNode.cs
@@ -34,13 +34,13 @@ namespace KSPCompiler.Domain.Ast.Nodes.Blocks
         ///
         /// <inheritdoc/>
         ///
-        public override T Accept<T>( IAstVisitor<T> visitor )
+        public override IAstNode Accept( IAstVisitor visitor )
             => visitor.Visit( this );
 
         ///
         /// <inheritdoc/>
         ///
-        public override void AcceptChildren<T>( IAstVisitor<T> visitor )
+        public override void AcceptChildren( IAstVisitor visitor )
         {
             foreach( var n in Statements )
             {

--- a/Compiler/Domain/Ast/Nodes/Blocks/AstCallbackDeclarationNode.cs
+++ b/Compiler/Domain/Ast/Nodes/Blocks/AstCallbackDeclarationNode.cs
@@ -33,7 +33,7 @@ namespace KSPCompiler.Domain.Ast.Nodes.Blocks
         ///
         /// <inheritdoc/>
         ///
-        public override T Accept<T>( IAstVisitor<T> visitor )
+        public override IAstNode Accept( IAstVisitor visitor )
             => visitor.Visit( this );
 
 

--- a/Compiler/Domain/Ast/Nodes/Blocks/AstCaseBlock.cs
+++ b/Compiler/Domain/Ast/Nodes/Blocks/AstCaseBlock.cs
@@ -53,10 +53,10 @@ namespace KSPCompiler.Domain.Ast.Nodes.Blocks
         ///
         /// <inheritdoc/>
         ///
-        public override T Accept<T>( IAstVisitor<T> visitor )
+        public override IAstNode Accept( IAstVisitor visitor )
             => visitor.Visit( this );
 
-        public override void AcceptChildren<T>( IAstVisitor<T> visitor )
+        public override void AcceptChildren( IAstVisitor visitor )
         {
             CodeBlock.AcceptChildren( visitor );
         }

--- a/Compiler/Domain/Ast/Nodes/Blocks/AstCompilationUnitNode.cs
+++ b/Compiler/Domain/Ast/Nodes/Blocks/AstCompilationUnitNode.cs
@@ -29,13 +29,13 @@ namespace KSPCompiler.Domain.Ast.Nodes.Blocks
         ///
         /// <inheritdoc/>
         ///
-        public override T Accept<T>( IAstVisitor<T> visitor )
+        public override IAstNode Accept( IAstVisitor visitor )
             => visitor.Visit( this );
 
         ///
         /// <inheritdoc/>
         ///
-        public override void AcceptChildren<T>( IAstVisitor<T> visitor )
+        public override void AcceptChildren( IAstVisitor visitor )
         {
             foreach( var n in GlobalBlocks )
             {

--- a/Compiler/Domain/Ast/Nodes/Blocks/AstUserFunctionDeclarationNode.cs
+++ b/Compiler/Domain/Ast/Nodes/Blocks/AstUserFunctionDeclarationNode.cs
@@ -24,7 +24,7 @@ namespace KSPCompiler.Domain.Ast.Nodes.Blocks
         ///
         /// <inheritdoc/>
         ///
-        public override T Accept<T>( IAstVisitor<T> visitor )
+        public override IAstNode Accept( IAstVisitor visitor )
             => visitor.Visit( this );
 
 

--- a/Compiler/Domain/Ast/Nodes/Expressions/AstAdditionExpressionNode.cs
+++ b/Compiler/Domain/Ast/Nodes/Expressions/AstAdditionExpressionNode.cs
@@ -40,7 +40,7 @@ namespace KSPCompiler.Domain.Ast.Nodes.Expressions
         ///
         /// <inheritdoc/>
         ///
-        public override T Accept<T>( IAstVisitor<T> visitor )
+        public override IAstNode Accept( IAstVisitor visitor )
             => visitor.Visit( this );
 
         #endregion IAstNodeAcceptor

--- a/Compiler/Domain/Ast/Nodes/Expressions/AstArrayElementExpressionNode.cs
+++ b/Compiler/Domain/Ast/Nodes/Expressions/AstArrayElementExpressionNode.cs
@@ -46,7 +46,7 @@ namespace KSPCompiler.Domain.Ast.Nodes.Expressions
         ///
         /// <inheritdoc/>
         ///
-        public override T Accept<T>( IAstVisitor<T> visitor )
+        public override IAstNode Accept( IAstVisitor visitor )
             => visitor.Visit( this );
 
         #endregion IAstNodeAcceptor

--- a/Compiler/Domain/Ast/Nodes/Expressions/AstAssignmentExpressionListNode.cs
+++ b/Compiler/Domain/Ast/Nodes/Expressions/AstAssignmentExpressionListNode.cs
@@ -45,13 +45,13 @@ namespace KSPCompiler.Domain.Ast.Nodes.Expressions
         ///
         /// <inheritdoc/>
         ///
-        public override T Accept<T>( IAstVisitor<T> visitor )
+        public override IAstNode Accept( IAstVisitor visitor )
             => visitor.Visit( this );
 
         ///
         /// <inheritdoc/>
         ///
-        public override void AcceptChildren<T>( IAstVisitor<T> visitor )
+        public override void AcceptChildren( IAstVisitor visitor )
         {
             foreach( var n in Expressions )
             {

--- a/Compiler/Domain/Ast/Nodes/Expressions/AstAssignmentExpressionNode.cs
+++ b/Compiler/Domain/Ast/Nodes/Expressions/AstAssignmentExpressionNode.cs
@@ -56,7 +56,7 @@ namespace KSPCompiler.Domain.Ast.Nodes.Expressions
         ///
         /// <inheritdoc/>
         ///
-        public override T Accept<T>( IAstVisitor<T> visitor )
+        public override IAstNode Accept( IAstVisitor visitor )
             => visitor.Visit( this );
 
         #endregion IAstNodeAcceptor

--- a/Compiler/Domain/Ast/Nodes/Expressions/AstBitwiseAndExpressionNode.cs
+++ b/Compiler/Domain/Ast/Nodes/Expressions/AstBitwiseAndExpressionNode.cs
@@ -40,7 +40,7 @@ namespace KSPCompiler.Domain.Ast.Nodes.Expressions
         ///
         /// <inheritdoc/>
         ///
-        public override T Accept<T>( IAstVisitor<T> visitor )
+        public override IAstNode Accept( IAstVisitor visitor )
             => visitor.Visit( this );
 
         #endregion IAstNodeAcceptor

--- a/Compiler/Domain/Ast/Nodes/Expressions/AstBitwiseOrExpressionNode.cs
+++ b/Compiler/Domain/Ast/Nodes/Expressions/AstBitwiseOrExpressionNode.cs
@@ -40,7 +40,7 @@ namespace KSPCompiler.Domain.Ast.Nodes.Expressions
         ///
         /// <inheritdoc/>
         ///
-        public override T Accept<T>( IAstVisitor<T> visitor )
+        public override IAstNode Accept( IAstVisitor visitor )
             => visitor.Visit( this );
 
         #endregion IAstNodeAcceptor

--- a/Compiler/Domain/Ast/Nodes/Expressions/AstBitwiseXorExpressionNode.cs
+++ b/Compiler/Domain/Ast/Nodes/Expressions/AstBitwiseXorExpressionNode.cs
@@ -40,7 +40,7 @@ namespace KSPCompiler.Domain.Ast.Nodes.Expressions
         ///
         /// <inheritdoc/>
         ///
-        public override T Accept<T>( IAstVisitor<T> visitor )
+        public override IAstNode Accept( IAstVisitor visitor )
             => visitor.Visit( this );
 
         #endregion IAstNodeAcceptor

--- a/Compiler/Domain/Ast/Nodes/Expressions/AstBooleanLiteralNode.cs
+++ b/Compiler/Domain/Ast/Nodes/Expressions/AstBooleanLiteralNode.cs
@@ -43,7 +43,7 @@ namespace KSPCompiler.Domain.Ast.Nodes.Expressions
         ///
         /// <inheritdoc/>
         ///
-        public override T Accept<T>( IAstVisitor<T> visitor )
+        public override IAstNode Accept( IAstVisitor visitor )
             => visitor.Visit( this );
 
         #endregion IAstNodeAcceptor

--- a/Compiler/Domain/Ast/Nodes/Expressions/AstCallCommandExpressionNode.cs
+++ b/Compiler/Domain/Ast/Nodes/Expressions/AstCallCommandExpressionNode.cs
@@ -44,7 +44,7 @@ namespace KSPCompiler.Domain.Ast.Nodes.Expressions
         ///
         /// <inheritdoc/>
         ///
-        public override T Accept<T>( IAstVisitor<T> visitor )
+        public override IAstNode Accept( IAstVisitor visitor )
             => visitor.Visit( this );
 
         #endregion IAstNodeAcceptor

--- a/Compiler/Domain/Ast/Nodes/Expressions/AstDefaultExpressionNode.cs
+++ b/Compiler/Domain/Ast/Nodes/Expressions/AstDefaultExpressionNode.cs
@@ -44,7 +44,7 @@ namespace KSPCompiler.Domain.Ast.Nodes.Expressions
         ///
         /// <inheritdoc/>
         ///
-        public override T Accept<T>( IAstVisitor<T> visitor )
+        public override IAstNode Accept( IAstVisitor visitor )
             => visitor.Visit( this );
 
         #endregion IAstNodeAcceptor

--- a/Compiler/Domain/Ast/Nodes/Expressions/AstDivisionExpressionNode.cs
+++ b/Compiler/Domain/Ast/Nodes/Expressions/AstDivisionExpressionNode.cs
@@ -40,7 +40,7 @@ namespace KSPCompiler.Domain.Ast.Nodes.Expressions
         ///
         /// <inheritdoc/>
         ///
-        public override T Accept<T>( IAstVisitor<T> visitor )
+        public override IAstNode Accept( IAstVisitor visitor )
             => visitor.Visit( this );
 
         #endregion IAstNodeAcceptor

--- a/Compiler/Domain/Ast/Nodes/Expressions/AstEqualExpressionNode.cs
+++ b/Compiler/Domain/Ast/Nodes/Expressions/AstEqualExpressionNode.cs
@@ -40,7 +40,7 @@ namespace KSPCompiler.Domain.Ast.Nodes.Expressions
         ///
         /// <inheritdoc/>
         ///
-        public override T Accept<T>( IAstVisitor<T> visitor )
+        public override IAstNode Accept( IAstVisitor visitor )
             => visitor.Visit( this );
 
         #endregion IAstNodeAcceptor

--- a/Compiler/Domain/Ast/Nodes/Expressions/AstExpressionListNode.cs
+++ b/Compiler/Domain/Ast/Nodes/Expressions/AstExpressionListNode.cs
@@ -46,13 +46,13 @@ namespace KSPCompiler.Domain.Ast.Nodes.Expressions
         ///
         /// <inheritdoc/>
         ///
-        public override T Accept<T>( IAstVisitor<T> visitor )
+        public override IAstNode Accept( IAstVisitor visitor )
             => visitor.Visit( this );
 
         ///
         /// <inheritdoc/>
         ///
-        public override void AcceptChildren<T>( IAstVisitor<T> visitor )
+        public override void AcceptChildren( IAstVisitor visitor )
         {
             foreach( var n in Expressions )
             {

--- a/Compiler/Domain/Ast/Nodes/Expressions/AstGreaterEqualExpressionNode.cs
+++ b/Compiler/Domain/Ast/Nodes/Expressions/AstGreaterEqualExpressionNode.cs
@@ -40,7 +40,7 @@ namespace KSPCompiler.Domain.Ast.Nodes.Expressions
         ///
         /// <inheritdoc/>
         ///
-        public override T Accept<T>( IAstVisitor<T> visitor )
+        public override IAstNode Accept( IAstVisitor visitor )
             => visitor.Visit( this );
 
         #endregion IAstNodeAcceptor

--- a/Compiler/Domain/Ast/Nodes/Expressions/AstGreaterThanExpressionNode.cs
+++ b/Compiler/Domain/Ast/Nodes/Expressions/AstGreaterThanExpressionNode.cs
@@ -40,7 +40,7 @@ namespace KSPCompiler.Domain.Ast.Nodes.Expressions
         ///
         /// <inheritdoc/>
         ///
-        public override T Accept<T>( IAstVisitor<T> visitor )
+        public override IAstNode Accept( IAstVisitor visitor )
             => visitor.Visit( this );
 
         #endregion IAstNodeAcceptor

--- a/Compiler/Domain/Ast/Nodes/Expressions/AstIntLiteralNode.cs
+++ b/Compiler/Domain/Ast/Nodes/Expressions/AstIntLiteralNode.cs
@@ -44,7 +44,7 @@ namespace KSPCompiler.Domain.Ast.Nodes.Expressions
         ///
         /// <inheritdoc/>
         ///
-        public override T Accept<T>( IAstVisitor<T> visitor )
+        public override IAstNode Accept( IAstVisitor visitor )
             => visitor.Visit( this );
 
         #endregion IAstNodeAcceptor

--- a/Compiler/Domain/Ast/Nodes/Expressions/AstLessEqualExpressionNode.cs
+++ b/Compiler/Domain/Ast/Nodes/Expressions/AstLessEqualExpressionNode.cs
@@ -40,7 +40,7 @@ namespace KSPCompiler.Domain.Ast.Nodes.Expressions
         ///
         /// <inheritdoc/>
         ///
-        public override T Accept<T>( IAstVisitor<T> visitor )
+        public override IAstNode Accept( IAstVisitor visitor )
             => visitor.Visit( this );
 
         #endregion IAstNodeAcceptor

--- a/Compiler/Domain/Ast/Nodes/Expressions/AstLessThanExpressionNode.cs
+++ b/Compiler/Domain/Ast/Nodes/Expressions/AstLessThanExpressionNode.cs
@@ -40,7 +40,7 @@ namespace KSPCompiler.Domain.Ast.Nodes.Expressions
         ///
         /// <inheritdoc/>
         ///
-        public override T Accept<T>( IAstVisitor<T> visitor )
+        public override IAstNode Accept( IAstVisitor visitor )
             => visitor.Visit( this );
 
         #endregion IAstNodeAcceptor

--- a/Compiler/Domain/Ast/Nodes/Expressions/AstLiteralNode.cs
+++ b/Compiler/Domain/Ast/Nodes/Expressions/AstLiteralNode.cs
@@ -43,7 +43,7 @@ namespace KSPCompiler.Domain.Ast.Nodes.Expressions
         ///
         /// <inheritdoc/>
         ///
-        public override T Accept<T>( IAstVisitor<T> visitor )
+        public override IAstNode Accept( IAstVisitor visitor )
             => visitor.Visit( this );
 
         #endregion IAstNodeAcceptor

--- a/Compiler/Domain/Ast/Nodes/Expressions/AstLogicalAndExpressionNode.cs
+++ b/Compiler/Domain/Ast/Nodes/Expressions/AstLogicalAndExpressionNode.cs
@@ -40,7 +40,7 @@ namespace KSPCompiler.Domain.Ast.Nodes.Expressions
         ///
         /// <inheritdoc/>
         ///
-        public override T Accept<T>( IAstVisitor<T> visitor )
+        public override IAstNode Accept( IAstVisitor visitor )
             => visitor.Visit( this );
 
         #endregion IAstNodeAcceptor

--- a/Compiler/Domain/Ast/Nodes/Expressions/AstLogicalOrExpressionNode.cs
+++ b/Compiler/Domain/Ast/Nodes/Expressions/AstLogicalOrExpressionNode.cs
@@ -40,7 +40,7 @@ namespace KSPCompiler.Domain.Ast.Nodes.Expressions
         ///
         /// <inheritdoc/>
         ///
-        public override T Accept<T>( IAstVisitor<T> visitor )
+        public override IAstNode Accept( IAstVisitor visitor )
             => visitor.Visit( this );
 
         #endregion IAstNodeAcceptor

--- a/Compiler/Domain/Ast/Nodes/Expressions/AstLogicalXorExpressionNode.cs
+++ b/Compiler/Domain/Ast/Nodes/Expressions/AstLogicalXorExpressionNode.cs
@@ -40,7 +40,7 @@ namespace KSPCompiler.Domain.Ast.Nodes.Expressions
         ///
         /// <inheritdoc/>
         ///
-        public override T Accept<T>( IAstVisitor<T> visitor )
+        public override IAstNode Accept( IAstVisitor visitor )
             => visitor.Visit( this );
 
         #endregion IAstNodeAcceptor

--- a/Compiler/Domain/Ast/Nodes/Expressions/AstModuloExpressionNode.cs
+++ b/Compiler/Domain/Ast/Nodes/Expressions/AstModuloExpressionNode.cs
@@ -40,7 +40,7 @@ namespace KSPCompiler.Domain.Ast.Nodes.Expressions
         ///
         /// <inheritdoc/>
         ///
-        public override T Accept<T>( IAstVisitor<T> visitor )
+        public override IAstNode Accept( IAstVisitor visitor )
             => visitor.Visit( this );
 
         #endregion IAstNodeAcceptor

--- a/Compiler/Domain/Ast/Nodes/Expressions/AstMultiplyingExpressionNode.cs
+++ b/Compiler/Domain/Ast/Nodes/Expressions/AstMultiplyingExpressionNode.cs
@@ -40,7 +40,7 @@ namespace KSPCompiler.Domain.Ast.Nodes.Expressions
         ///
         /// <inheritdoc/>
         ///
-        public override T Accept<T>( IAstVisitor<T> visitor )
+        public override IAstNode Accept( IAstVisitor visitor )
             => visitor.Visit( this );
 
         #endregion IAstNodeAcceptor

--- a/Compiler/Domain/Ast/Nodes/Expressions/AstNotEqualExpressionNode.cs
+++ b/Compiler/Domain/Ast/Nodes/Expressions/AstNotEqualExpressionNode.cs
@@ -40,7 +40,7 @@ namespace KSPCompiler.Domain.Ast.Nodes.Expressions
         ///
         /// <inheritdoc/>
         ///
-        public override T Accept<T>( IAstVisitor<T> visitor )
+        public override IAstNode Accept( IAstVisitor visitor )
             => visitor.Visit( this );
 
         #endregion IAstNodeAcceptor

--- a/Compiler/Domain/Ast/Nodes/Expressions/AstRealLiteralNode.cs
+++ b/Compiler/Domain/Ast/Nodes/Expressions/AstRealLiteralNode.cs
@@ -43,7 +43,7 @@ namespace KSPCompiler.Domain.Ast.Nodes.Expressions
         ///
         /// <inheritdoc/>
         ///
-        public override T Accept<T>( IAstVisitor<T> visitor )
+        public override IAstNode Accept( IAstVisitor visitor )
             => visitor.Visit( this );
 
         #endregion IAstNodeAcceptor

--- a/Compiler/Domain/Ast/Nodes/Expressions/AstStringConcatenateExpressionNode.cs
+++ b/Compiler/Domain/Ast/Nodes/Expressions/AstStringConcatenateExpressionNode.cs
@@ -40,7 +40,7 @@ namespace KSPCompiler.Domain.Ast.Nodes.Expressions
         ///
         /// <inheritdoc/>
         ///
-        public override T Accept<T>( IAstVisitor<T> visitor )
+        public override IAstNode Accept( IAstVisitor visitor )
             => visitor.Visit( this );
 
         #endregion IAstNodeAcceptor

--- a/Compiler/Domain/Ast/Nodes/Expressions/AstStringLiteralNode.cs
+++ b/Compiler/Domain/Ast/Nodes/Expressions/AstStringLiteralNode.cs
@@ -43,7 +43,7 @@ namespace KSPCompiler.Domain.Ast.Nodes.Expressions
         ///
         /// <inheritdoc/>
         ///
-        public override T Accept<T>( IAstVisitor<T> visitor )
+        public override IAstNode Accept( IAstVisitor visitor )
             => visitor.Visit( this );
 
         #endregion IAstNodeAcceptor

--- a/Compiler/Domain/Ast/Nodes/Expressions/AstSubtractionExpressionNode.cs
+++ b/Compiler/Domain/Ast/Nodes/Expressions/AstSubtractionExpressionNode.cs
@@ -40,7 +40,7 @@ namespace KSPCompiler.Domain.Ast.Nodes.Expressions
         ///
         /// <inheritdoc/>
         ///
-        public override T Accept<T>( IAstVisitor<T> visitor )
+        public override IAstNode Accept( IAstVisitor visitor )
             => visitor.Visit( this );
 
         #endregion IAstNodeAcceptor

--- a/Compiler/Domain/Ast/Nodes/Expressions/AstSymbolExpressionNode.cs
+++ b/Compiler/Domain/Ast/Nodes/Expressions/AstSymbolExpressionNode.cs
@@ -60,7 +60,7 @@ namespace KSPCompiler.Domain.Ast.Nodes.Expressions
         ///
         /// <inheritdoc/>
         ///
-        public override T Accept<T>( IAstVisitor<T> visitor )
+        public override IAstNode Accept( IAstVisitor visitor )
             => visitor.Visit( this );
 
         #endregion IAstNodeAcceptor

--- a/Compiler/Domain/Ast/Nodes/Expressions/AstUnaryLogicalNotExpressionNode.cs
+++ b/Compiler/Domain/Ast/Nodes/Expressions/AstUnaryLogicalNotExpressionNode.cs
@@ -39,7 +39,7 @@ namespace KSPCompiler.Domain.Ast.Nodes.Expressions
         ///
         /// <inheritdoc/>
         ///
-        public override T Accept<T>( IAstVisitor<T> visitor )
+        public override IAstNode Accept( IAstVisitor visitor )
             => visitor.Visit( this );
 
         #endregion IAstNodeAcceptor

--- a/Compiler/Domain/Ast/Nodes/Expressions/AstUnaryMinusExpressionNode.cs
+++ b/Compiler/Domain/Ast/Nodes/Expressions/AstUnaryMinusExpressionNode.cs
@@ -39,7 +39,7 @@ namespace KSPCompiler.Domain.Ast.Nodes.Expressions
         ///
         /// <inheritdoc/>
         ///
-        public override T Accept<T>( IAstVisitor<T> visitor )
+        public override IAstNode Accept( IAstVisitor visitor )
             => visitor.Visit( this );
 
         #endregion IAstNodeAcceptor

--- a/Compiler/Domain/Ast/Nodes/Expressions/AstUnaryNotExpressionNode.cs
+++ b/Compiler/Domain/Ast/Nodes/Expressions/AstUnaryNotExpressionNode.cs
@@ -39,7 +39,7 @@ namespace KSPCompiler.Domain.Ast.Nodes.Expressions
         ///
         /// <inheritdoc/>
         ///
-        public override T Accept<T>( IAstVisitor<T> visitor )
+        public override IAstNode Accept( IAstVisitor visitor )
             => visitor.Visit( this );
 
         #endregion IAstNodeAcceptor

--- a/Compiler/Domain/Ast/Nodes/IAstNodeAcceptor.cs
+++ b/Compiler/Domain/Ast/Nodes/IAstNodeAcceptor.cs
@@ -13,11 +13,11 @@
         /// <summary>
         /// Acceptance process for visitors.
         /// </summary>
-        public T Accept<T>( IAstVisitor<T> visitor );
+        public IAstNode Accept( IAstVisitor visitor );
 
         /// <summary>
         /// Acceptance process of a visitor to a contained node such as a child node.
         /// </summary>
-        public void AcceptChildren<T>( IAstVisitor<T> visitor );
+        public void AcceptChildren( IAstVisitor visitor );
     }
 }

--- a/Compiler/Domain/Ast/Nodes/NullAstExpressionNode.cs
+++ b/Compiler/Domain/Ast/Nodes/NullAstExpressionNode.cs
@@ -68,13 +68,13 @@ public sealed class NullAstExpressionNode : AstExpressionNode
     ///
     /// <inheritdoc/>
     ///
-    public override T Accept<T>( IAstVisitor<T> visitor )
+    public override IAstNode Accept( IAstVisitor visitor )
         => visitor.Visit( this );
 
     /// <summary>
     /// Do nothing.
     /// </summary>
-    public override void AcceptChildren<T>( IAstVisitor<T> visitor ) {}
+    public override void AcceptChildren( IAstVisitor visitor ) {}
     #endregion IAstNodeAcceptor
 
     public override string ToString()

--- a/Compiler/Domain/Ast/Nodes/NullAstNode.cs
+++ b/Compiler/Domain/Ast/Nodes/NullAstNode.cs
@@ -72,13 +72,13 @@ namespace KSPCompiler.Domain.Ast.Nodes
         ///
         /// <inheritdoc/>
         ///
-        public T Accept<T>( IAstVisitor<T> visitor )
+        public IAstNode Accept( IAstVisitor visitor )
             => visitor.Visit( this );
 
         /// <summary>
         /// Do nothing.
         /// </summary>
-        public void AcceptChildren<T>( IAstVisitor<T> visitor ) {}
+        public void AcceptChildren( IAstVisitor visitor ) {}
         #endregion IAstNodeAcceptor
 
         public override string ToString()

--- a/Compiler/Domain/Ast/Nodes/Statements/AstArrayInitializerNode.cs
+++ b/Compiler/Domain/Ast/Nodes/Statements/AstArrayInitializerNode.cs
@@ -56,13 +56,13 @@ namespace KSPCompiler.Domain.Ast.Nodes.Statements
         ///
         /// <inheritdoc/>
         ///
-        public override T Accept<T>( IAstVisitor<T> visitor )
+        public override IAstNode Accept( IAstVisitor visitor )
             => visitor.Visit( this );
 
         ///
         /// <inheritdoc/>
         ///
-        public override void AcceptChildren<T>( IAstVisitor<T> visitor )
+        public override void AcceptChildren( IAstVisitor visitor )
         {
             // Do nothing
         }

--- a/Compiler/Domain/Ast/Nodes/Statements/AstCallKspUserFunctionStatementNode.cs
+++ b/Compiler/Domain/Ast/Nodes/Statements/AstCallKspUserFunctionStatementNode.cs
@@ -40,13 +40,13 @@ namespace KSPCompiler.Domain.Ast.Nodes.Statements
         ///
         /// <inheritdoc/>
         ///
-        public override T Accept<T>( IAstVisitor<T> visitor )
+        public override IAstNode Accept( IAstVisitor visitor )
             => visitor.Visit( this );
 
         ///
         /// <inheritdoc/>
         ///
-        public override void AcceptChildren<T>( IAstVisitor<T> visitor )
+        public override void AcceptChildren( IAstVisitor visitor )
         {
             // Do nothing
         }

--- a/Compiler/Domain/Ast/Nodes/Statements/AstContinueStatementNode.cs
+++ b/Compiler/Domain/Ast/Nodes/Statements/AstContinueStatementNode.cs
@@ -31,13 +31,13 @@ namespace KSPCompiler.Domain.Ast.Nodes.Statements
         ///
         /// <inheritdoc/>
         ///
-        public override T Accept<T>( IAstVisitor<T> visitor )
+        public override IAstNode Accept( IAstVisitor visitor )
             => visitor.Visit( this );
 
         ///
         /// <inheritdoc/>
         ///
-        public override void AcceptChildren<T>( IAstVisitor<T> visitor )
+        public override void AcceptChildren( IAstVisitor visitor )
         {
             // Do nothing
         }

--- a/Compiler/Domain/Ast/Nodes/Statements/AstIfStatementNode.cs
+++ b/Compiler/Domain/Ast/Nodes/Statements/AstIfStatementNode.cs
@@ -54,7 +54,7 @@ namespace KSPCompiler.Domain.Ast.Nodes.Statements
         ///
         /// <inheritdoc/>
         ///
-        public override T Accept<T>( IAstVisitor<T> visitor )
+        public override IAstNode Accept( IAstVisitor visitor )
             => visitor.Visit( this );
 
         #endregion IAstNodeAcceptor

--- a/Compiler/Domain/Ast/Nodes/Statements/AstKspPreprocessorDefineNode.cs
+++ b/Compiler/Domain/Ast/Nodes/Statements/AstKspPreprocessorDefineNode.cs
@@ -44,13 +44,13 @@ namespace KSPCompiler.Domain.Ast.Nodes.Statements
         ///
         /// <inheritdoc/>
         ///
-        public override T Accept<T>( IAstVisitor<T> visitor )
+        public override IAstNode Accept( IAstVisitor visitor )
             => visitor.Visit( this );
 
         ///
         /// <inheritdoc/>
         ///
-        public override void AcceptChildren<T>( IAstVisitor<T> visitor )
+        public override void AcceptChildren( IAstVisitor visitor )
         {
             // Do nothing
         }

--- a/Compiler/Domain/Ast/Nodes/Statements/AstKspPreprocessorIfdefineNode.cs
+++ b/Compiler/Domain/Ast/Nodes/Statements/AstKspPreprocessorIfdefineNode.cs
@@ -46,13 +46,13 @@ namespace KSPCompiler.Domain.Ast.Nodes.Statements
         ///
         /// <inheritdoc/>
         ///
-        public override T Accept<T>( IAstVisitor<T> visitor )
+        public override IAstNode Accept( IAstVisitor visitor )
             => visitor.Visit( this );
 
         ///
         /// <inheritdoc/>
         ///
-        public override void AcceptChildren<T>( IAstVisitor<T> visitor )
+        public override void AcceptChildren( IAstVisitor visitor )
         {
             throw new NotImplementedException();
         }

--- a/Compiler/Domain/Ast/Nodes/Statements/AstKspPreprocessorIfnotDefineNode.cs
+++ b/Compiler/Domain/Ast/Nodes/Statements/AstKspPreprocessorIfnotDefineNode.cs
@@ -46,13 +46,13 @@ namespace KSPCompiler.Domain.Ast.Nodes.Statements
         ///
         /// <inheritdoc/>
         ///
-        public override T Accept<T>( IAstVisitor<T> visitor )
+        public override IAstNode Accept( IAstVisitor visitor )
             => visitor.Visit( this );
 
         ///
         /// <inheritdoc/>
         ///
-        public override void AcceptChildren<T>( IAstVisitor<T> visitor )
+        public override void AcceptChildren( IAstVisitor visitor )
         {
             throw new NotImplementedException();
         }

--- a/Compiler/Domain/Ast/Nodes/Statements/AstKspPreprocessorUndefineNode.cs
+++ b/Compiler/Domain/Ast/Nodes/Statements/AstKspPreprocessorUndefineNode.cs
@@ -44,13 +44,13 @@ namespace KSPCompiler.Domain.Ast.Nodes.Statements
         ///
         /// <inheritdoc/>
         ///
-        public override T Accept<T>( IAstVisitor<T> visitor )
+        public override IAstNode Accept( IAstVisitor visitor )
             => visitor.Visit( this );
 
         ///
         /// <inheritdoc/>
         ///
-        public override void AcceptChildren<T>( IAstVisitor<T> visitor )
+        public override void AcceptChildren( IAstVisitor visitor )
         {
             throw new NotImplementedException();
         }

--- a/Compiler/Domain/Ast/Nodes/Statements/AstPrimitiveInitializerNode.cs
+++ b/Compiler/Domain/Ast/Nodes/Statements/AstPrimitiveInitializerNode.cs
@@ -44,13 +44,13 @@ namespace KSPCompiler.Domain.Ast.Nodes.Statements
         ///
         /// <inheritdoc/>
         ///
-        public override T Accept<T>( IAstVisitor<T> visitor )
+        public override IAstNode Accept( IAstVisitor visitor )
             => visitor.Visit( this );
 
         ///
         /// <inheritdoc/>
         ///
-        public override void AcceptChildren<T>( IAstVisitor<T> visitor )
+        public override void AcceptChildren( IAstVisitor visitor )
         {
             // Do nothing
         }

--- a/Compiler/Domain/Ast/Nodes/Statements/AstSelectStatementNode.cs
+++ b/Compiler/Domain/Ast/Nodes/Statements/AstSelectStatementNode.cs
@@ -43,13 +43,13 @@ namespace KSPCompiler.Domain.Ast.Nodes.Statements
         ///
         /// <inheritdoc/>
         ///
-        public override T Accept<T>( IAstVisitor<T> visitor )
+        public override IAstNode Accept( IAstVisitor visitor )
             => visitor.Visit( this );
 
         ///
         /// <inheritdoc/>
         ///
-        public override void AcceptChildren<T>( IAstVisitor<T> visitor )
+        public override void AcceptChildren( IAstVisitor visitor )
         {
             Condition.AcceptChildren( visitor );
 

--- a/Compiler/Domain/Ast/Nodes/Statements/AstVariableDeclarationNode.cs
+++ b/Compiler/Domain/Ast/Nodes/Statements/AstVariableDeclarationNode.cs
@@ -46,13 +46,13 @@ namespace KSPCompiler.Domain.Ast.Nodes.Statements
         ///
         /// <inheritdoc/>
         ///
-        public override T Accept<T>( IAstVisitor<T> visitor )
+        public override IAstNode Accept( IAstVisitor visitor )
             => visitor.Visit( this );
 
         ///
         /// <inheritdoc/>
         ///
-        public override void AcceptChildren<T>( IAstVisitor<T> visitor )
+        public override void AcceptChildren( IAstVisitor visitor )
         {
             Modifier.AcceptChildren( visitor );
             Initializer.AcceptChildren( visitor );

--- a/Compiler/Domain/Ast/Nodes/Statements/AstVariableInitializerNode.cs
+++ b/Compiler/Domain/Ast/Nodes/Statements/AstVariableInitializerNode.cs
@@ -55,13 +55,13 @@ namespace KSPCompiler.Domain.Ast.Nodes.Statements
         ///
         /// <inheritdoc/>
         ///
-        public override T Accept<T>( IAstVisitor<T> visitor )
+        public override IAstNode Accept( IAstVisitor visitor )
             => visitor.Visit( this );
 
         ///
         /// <inheritdoc/>
         ///
-        public override void AcceptChildren<T>( IAstVisitor<T> visitor )
+        public override void AcceptChildren( IAstVisitor visitor )
         {
 
             PrimitiveInitializer.AcceptChildren( visitor );

--- a/Compiler/Domain/Ast/Nodes/Statements/AstWhileStatementNode.cs
+++ b/Compiler/Domain/Ast/Nodes/Statements/AstWhileStatementNode.cs
@@ -30,7 +30,7 @@ namespace KSPCompiler.Domain.Ast.Nodes.Statements
         ///
         /// <inheritdoc/>
         ///
-        public override T Accept<T>( IAstVisitor<T> visitor )
+        public override IAstNode Accept( IAstVisitor visitor )
             => visitor.Visit( this );
 
         #endregion IAstNodeAcceptor

--- a/Compiler/Domain/Ast/Nodes/Statements/NullAstVariableInitializerNode.cs
+++ b/Compiler/Domain/Ast/Nodes/Statements/NullAstVariableInitializerNode.cs
@@ -42,10 +42,10 @@ public sealed class NullAstVariableInitializerNode : AstVariableInitializerNode
     public override int ChildNodeCount
         => 0;
 
-    public override T Accept<T>( IAstVisitor<T> visitor )
+    public override IAstNode Accept( IAstVisitor visitor )
         => visitor.Visit( this );
 
-    public override void AcceptChildren<T>( IAstVisitor<T> visitor ) {}
+    public override void AcceptChildren( IAstVisitor visitor ) {}
 
     public override string ToString()
         => nameof( NullAstVariableInitializerNode );

--- a/Tools/SimpleCodeGenerator/templates/ast/block.cs
+++ b/Tools/SimpleCodeGenerator/templates/ast/block.cs
@@ -23,7 +23,7 @@ namespace ${namespace}
         ///
         /// <inheritdoc/>
         ///
-        public override T Accept<T>( IAstVisitor<T> visitor )
+        public override IAstNode Accept( IAstVisitor visitor )
             => visitor.Visit( this );
 
 

--- a/Tools/SimpleCodeGenerator/templates/ast/expression.cs
+++ b/Tools/SimpleCodeGenerator/templates/ast/expression.cs
@@ -40,8 +40,8 @@ namespace ${namespace}
         ///
         /// <inheritdoc/>
         ///
-        public override T Accept<T>( IAstVisitor<T> visitor, AbortTraverseToken abortTraverseToken )
-            => visitor.Visit( this, abortTraverseToken );
+        public override IAstNode Accept( IAstVisitor visitor )
+            => visitor.Visit( this );
 
         #endregion IAstNodeAcceptor
     }

--- a/Tools/SimpleCodeGenerator/templates/ast/statement.cs
+++ b/Tools/SimpleCodeGenerator/templates/ast/statement.cs
@@ -23,13 +23,13 @@ namespace ${namespace}
         ///
         /// <inheritdoc/>
         ///
-        public override T Accept<T>( IAstVisitor<T> visitor )
+        public override IAstNode Accept( IAstVisitor visitor )
             => visitor.Visit( this );
 
         ///
         /// <inheritdoc/>
         ///
-        public override void AcceptChildren<T>( IAstVisitor<T> visitor )
+        public override void AcceptChildren( IAstVisitor visitor )
         {
             throw new System.NotImplementedException();
         }


### PR DESCRIPTION
Organized the mix of IAstVisitor with and without generics, and modified it to be passed as an argument instead of a member.

ジェネリクスあり・なしの IAstVisitorの混在を整理、メンバではなく引数で渡すように修正