### PR TITLE
Fix/convolution evaluations

### DIFF
--- a/Compiler/Domain.Tests/Analyzer/Semantics/AstIncompatibleBinaryOperatorEvaluationTest.cs
+++ b/Compiler/Domain.Tests/Analyzer/Semantics/AstIncompatibleBinaryOperatorEvaluationTest.cs
@@ -5,7 +5,6 @@ using KSPCompiler.Domain.Ast.Analyzers.Semantics;
 using KSPCompiler.Domain.Ast.Nodes;
 using KSPCompiler.Domain.Ast.Nodes.Expressions;
 using KSPCompiler.Domain.CompilerMessages;
-using KSPCompiler.Domain.Symbols;
 using KSPCompiler.Domain.Symbols.MetaData;
 using KSPCompiler.Domain.Symbols.MetaData.Extensions;
 
@@ -24,15 +23,8 @@ public class AstIncompatibleBinaryOperatorEvaluationTest
 
         var compilerMessageManger = ICompilerMessageManger.Default;
         var visitor = new MockAstBinaryOperatorVisitor();
-        var variableTable = new VariableSymbolTable();
-        var variable = MockUtility.CreateIntVariable( variableName );
-        variableTable.Add( variable );
 
-        var integerConvolutionEvaluator = new IntegerConvolutionEvaluator(
-            visitor,
-            variableTable,
-            compilerMessageManger
-        );
+        var integerConvolutionEvaluator = new IntegerConvolutionEvaluator();
         var realConvolutionEvaluator = new MockRealConvolutionEvaluator();
         var binaryOperatorEvaluator = new NumericBinaryOperatorEvaluator(
             compilerMessageManger,

--- a/Compiler/Domain.Tests/Analyzer/Semantics/AstIntBinaryOperatorConvolutionTest.cs
+++ b/Compiler/Domain.Tests/Analyzer/Semantics/AstIntBinaryOperatorConvolutionTest.cs
@@ -5,7 +5,6 @@ using KSPCompiler.Domain.Ast.Analyzers.Semantics;
 using KSPCompiler.Domain.Ast.Nodes;
 using KSPCompiler.Domain.Ast.Nodes.Expressions;
 using KSPCompiler.Domain.CompilerMessages;
-using KSPCompiler.Domain.Symbols;
 
 using NUnit.Framework;
 
@@ -18,13 +17,8 @@ public class AstIntBinaryOperatorConvolutionTest
     {
         var compilerMessageManger = ICompilerMessageManger.Default;
         var visitor = new MockAstBinaryOperatorVisitor();
-        var variableTable = new VariableSymbolTable();
 
-        var integerConvolutionEvaluator = new IntegerConvolutionEvaluator(
-            visitor,
-            variableTable,
-            compilerMessageManger
-        );
+        var integerConvolutionEvaluator = new IntegerConvolutionEvaluator();
         var realConvolutionEvaluator = new MockRealConvolutionEvaluator();
         var binaryOperatorEvaluator = new NumericBinaryOperatorEvaluator(
             compilerMessageManger,

--- a/Compiler/Domain.Tests/Analyzer/Semantics/AstIntBinaryOperatorEvaluationTest.cs
+++ b/Compiler/Domain.Tests/Analyzer/Semantics/AstIntBinaryOperatorEvaluationTest.cs
@@ -5,7 +5,6 @@ using KSPCompiler.Domain.Ast.Analyzers.Semantics;
 using KSPCompiler.Domain.Ast.Nodes;
 using KSPCompiler.Domain.Ast.Nodes.Expressions;
 using KSPCompiler.Domain.CompilerMessages;
-using KSPCompiler.Domain.Symbols;
 using KSPCompiler.Domain.Symbols.MetaData;
 using KSPCompiler.Domain.Symbols.MetaData.Extensions;
 
@@ -26,14 +25,8 @@ public class AstIntBinaryOperatorEvaluationTest
 
         var compilerMessageManger = ICompilerMessageManger.Default;
         var visitor = new MockAstBinaryOperatorVisitor();
-        var variableTable = new VariableSymbolTable();
-        variableTable.Add( MockUtility.CreateIntVariable( variableName ) );
 
-        var integerConvolutionEvaluator = new IntegerConvolutionEvaluator(
-            visitor,
-            variableTable,
-            compilerMessageManger
-        );
+        var integerConvolutionEvaluator = new IntegerConvolutionEvaluator();
         var realConvolutionEvaluator = new MockRealConvolutionEvaluator();
         var binaryOperatorEvaluator = new NumericBinaryOperatorEvaluator(
             compilerMessageManger,
@@ -60,14 +53,8 @@ public class AstIntBinaryOperatorEvaluationTest
 
         var compilerMessageManger = ICompilerMessageManger.Default;
         var visitor = new MockAstBinaryOperatorVisitor();
-        var variableTable = new VariableSymbolTable();
-        variableTable.Add( MockUtility.CreateIntVariable( variableName ) );
 
-        var integerConvolutionEvaluator = new IntegerConvolutionEvaluator(
-            visitor,
-            variableTable,
-            compilerMessageManger
-        );
+        var integerConvolutionEvaluator = new IntegerConvolutionEvaluator();
         var realConvolutionEvaluator = new MockRealConvolutionEvaluator();
         var binaryOperatorEvaluator = new NumericBinaryOperatorEvaluator(
             compilerMessageManger,
@@ -94,14 +81,8 @@ public class AstIntBinaryOperatorEvaluationTest
 
         var compilerMessageManger = ICompilerMessageManger.Default;
         var visitor = new MockAstBinaryOperatorVisitor();
-        var variableTable = new VariableSymbolTable();
-        variableTable.Add( MockUtility.CreateIntVariable( variableName ) );
 
-        var integerConvolutionEvaluator = new IntegerConvolutionEvaluator(
-            visitor,
-            variableTable,
-            compilerMessageManger
-        );
+        var integerConvolutionEvaluator = new IntegerConvolutionEvaluator();
         var realConvolutionEvaluator = new MockRealConvolutionEvaluator();
         var binaryOperatorEvaluator = new NumericBinaryOperatorEvaluator(
             compilerMessageManger,
@@ -128,14 +109,8 @@ public class AstIntBinaryOperatorEvaluationTest
 
         var compilerMessageManger = ICompilerMessageManger.Default;
         var visitor = new MockAstBinaryOperatorVisitor();
-        var variableTable = new VariableSymbolTable();
-        variableTable.Add( MockUtility.CreateIntVariable( variableName ) );
 
-        var integerConvolutionEvaluator = new IntegerConvolutionEvaluator(
-            visitor,
-            variableTable,
-            compilerMessageManger
-        );
+        var integerConvolutionEvaluator = new IntegerConvolutionEvaluator();
         var realConvolutionEvaluator = new MockRealConvolutionEvaluator();
         var binaryOperatorEvaluator = new NumericBinaryOperatorEvaluator(
             compilerMessageManger,
@@ -163,14 +138,8 @@ public class AstIntBinaryOperatorEvaluationTest
 
         var compilerMessageManger = ICompilerMessageManger.Default;
         var visitor = new MockAstBinaryOperatorVisitor();
-        var variableTable = new VariableSymbolTable();
-        variableTable.Add( MockUtility.CreateIntVariable( variableName ) );
 
-        var integerConvolutionEvaluator = new IntegerConvolutionEvaluator(
-            visitor,
-            variableTable,
-            compilerMessageManger
-        );
+        var integerConvolutionEvaluator = new IntegerConvolutionEvaluator();
         var realConvolutionEvaluator = new MockRealConvolutionEvaluator();
         var binaryOperatorEvaluator = new NumericBinaryOperatorEvaluator(
             compilerMessageManger,
@@ -200,14 +169,8 @@ public class AstIntBinaryOperatorEvaluationTest
 
         var compilerMessageManger = ICompilerMessageManger.Default;
         var visitor = new MockAstBinaryOperatorVisitor();
-        var variableTable = new VariableSymbolTable();
-        variableTable.Add( MockUtility.CreateIntVariable( variableName ) );
 
-        var integerConvolutionEvaluator = new IntegerConvolutionEvaluator(
-            visitor,
-            variableTable,
-            compilerMessageManger
-        );
+        var integerConvolutionEvaluator = new IntegerConvolutionEvaluator();
         var realConvolutionEvaluator = new MockRealConvolutionEvaluator();
         var binaryOperatorEvaluator = new NumericBinaryOperatorEvaluator(
             compilerMessageManger,
@@ -235,14 +198,8 @@ public class AstIntBinaryOperatorEvaluationTest
 
         var compilerMessageManger = ICompilerMessageManger.Default;
         var visitor = new MockAstBinaryOperatorVisitor();
-        var variableTable = new VariableSymbolTable();
-        variableTable.Add( MockUtility.CreateIntVariable( variableName ) );
 
-        var integerConvolutionEvaluator = new IntegerConvolutionEvaluator(
-            visitor,
-            variableTable,
-            compilerMessageManger
-        );
+        var integerConvolutionEvaluator = new IntegerConvolutionEvaluator();
         var realConvolutionEvaluator = new MockRealConvolutionEvaluator();
         var binaryOperatorEvaluator = new NumericBinaryOperatorEvaluator(
             compilerMessageManger,
@@ -270,14 +227,8 @@ public class AstIntBinaryOperatorEvaluationTest
 
         var compilerMessageManger = ICompilerMessageManger.Default;
         var visitor = new MockAstBinaryOperatorVisitor();
-        var variableTable = new VariableSymbolTable();
-        variableTable.Add( MockUtility.CreateIntVariable( variableName ) );
 
-        var integerConvolutionEvaluator = new IntegerConvolutionEvaluator(
-            visitor,
-            variableTable,
-            compilerMessageManger
-        );
+        var integerConvolutionEvaluator = new IntegerConvolutionEvaluator();
         var realConvolutionEvaluator = new MockRealConvolutionEvaluator();
         var binaryOperatorEvaluator = new NumericBinaryOperatorEvaluator(
             compilerMessageManger,

--- a/Compiler/Domain.Tests/Analyzer/Semantics/AstIntUnaryOperatorEvaluationTest.cs
+++ b/Compiler/Domain.Tests/Analyzer/Semantics/AstIntUnaryOperatorEvaluationTest.cs
@@ -3,7 +3,6 @@ using System;
 using KSPCompiler.Domain.Ast.Analyzers.Evaluators.Convolutions.Integers;
 using KSPCompiler.Domain.Ast.Analyzers.Semantics;
 using KSPCompiler.Domain.CompilerMessages;
-using KSPCompiler.Domain.Symbols;
 using KSPCompiler.Domain.Symbols.MetaData;
 
 using NUnit.Framework;
@@ -20,14 +19,8 @@ public class AstIntUnaryOperatorEvaluationTest
 
         var compilerMessageManger = ICompilerMessageManger.Default;
         var visitor = new MockAstUnaryOperatorVisitor();
-        var variableTable = new VariableSymbolTable();
-        variableTable.Add( MockUtility.CreateIntVariable( variableName ) );
 
-        var integerConvolutionEvaluator = new IntegerConvolutionEvaluator(
-            visitor,
-            variableTable,
-            compilerMessageManger
-        );
+        var integerConvolutionEvaluator = new IntegerConvolutionEvaluator();
         var realConvolutionEvaluator = new MockRealConvolutionEvaluator();
         var unaryOperatorEvaluator = new NumericUnaryOperatorEvaluator(
             compilerMessageManger,
@@ -53,14 +46,8 @@ public class AstIntUnaryOperatorEvaluationTest
 
         var compilerMessageManger = ICompilerMessageManger.Default;
         var visitor = new MockAstUnaryOperatorVisitor();
-        var variableTable = new VariableSymbolTable();
-        variableTable.Add( MockUtility.CreateIntVariable( variableName ) );
 
-        var integerConvolutionEvaluator = new IntegerConvolutionEvaluator(
-            visitor,
-            variableTable,
-            compilerMessageManger
-        );
+        var integerConvolutionEvaluator = new IntegerConvolutionEvaluator();
         var realConvolutionEvaluator = new MockRealConvolutionEvaluator();
         var unaryOperatorEvaluator = new NumericUnaryOperatorEvaluator(
             compilerMessageManger,

--- a/Compiler/Domain.Tests/Analyzer/Semantics/AstRealBinaryOperatorEvaluationTest.cs
+++ b/Compiler/Domain.Tests/Analyzer/Semantics/AstRealBinaryOperatorEvaluationTest.cs
@@ -5,7 +5,6 @@ using KSPCompiler.Domain.Ast.Analyzers.Semantics;
 using KSPCompiler.Domain.Ast.Nodes;
 using KSPCompiler.Domain.Ast.Nodes.Expressions;
 using KSPCompiler.Domain.CompilerMessages;
-using KSPCompiler.Domain.Symbols;
 using KSPCompiler.Domain.Symbols.MetaData;
 using KSPCompiler.Domain.Symbols.MetaData.Extensions;
 
@@ -25,15 +24,9 @@ public class AstRealBinaryOperatorEvaluationTest
 
         var compilerMessageManger = ICompilerMessageManger.Default;
         var visitor = new MockAstBinaryOperatorVisitor();
-        var variableTable = new VariableSymbolTable();
-        variableTable.Add( MockUtility.CreateIntVariable( variableName ) );
 
         var integerConvolutionEvaluator = new MockIntegerConvolutionEvaluator();
-        var realConvolutionEvaluator = new RealConvolutionEvaluator(
-            visitor,
-            variableTable,
-            compilerMessageManger
-        );
+        var realConvolutionEvaluator = new RealConvolutionEvaluator();
         var binaryOperatorEvaluator = new NumericBinaryOperatorEvaluator(
             compilerMessageManger,
             integerConvolutionEvaluator,
@@ -60,15 +53,9 @@ public class AstRealBinaryOperatorEvaluationTest
 
         var compilerMessageManger = ICompilerMessageManger.Default;
         var visitor = new MockAstBinaryOperatorVisitor();
-        var variableTable = new VariableSymbolTable();
-        variableTable.Add( MockUtility.CreateIntVariable( variableName ) );
 
         var integerConvolutionEvaluator = new MockIntegerConvolutionEvaluator();
-        var realConvolutionEvaluator = new RealConvolutionEvaluator(
-            visitor,
-            variableTable,
-            compilerMessageManger
-        );
+        var realConvolutionEvaluator = new RealConvolutionEvaluator();
         var binaryOperatorEvaluator = new NumericBinaryOperatorEvaluator(
             compilerMessageManger,
             integerConvolutionEvaluator,
@@ -95,15 +82,9 @@ public class AstRealBinaryOperatorEvaluationTest
 
         var compilerMessageManger = ICompilerMessageManger.Default;
         var visitor = new MockAstBinaryOperatorVisitor();
-        var variableTable = new VariableSymbolTable();
-        variableTable.Add( MockUtility.CreateIntVariable( variableName ) );
 
         var integerConvolutionEvaluator = new MockIntegerConvolutionEvaluator();
-        var realConvolutionEvaluator = new RealConvolutionEvaluator(
-            visitor,
-            variableTable,
-            compilerMessageManger
-        );
+        var realConvolutionEvaluator = new RealConvolutionEvaluator();
         var binaryOperatorEvaluator = new NumericBinaryOperatorEvaluator(
             compilerMessageManger,
             integerConvolutionEvaluator,
@@ -130,15 +111,9 @@ public class AstRealBinaryOperatorEvaluationTest
 
         var compilerMessageManger = ICompilerMessageManger.Default;
         var visitor = new MockAstBinaryOperatorVisitor();
-        var variableTable = new VariableSymbolTable();
-        variableTable.Add( MockUtility.CreateIntVariable( variableName ) );
 
         var integerConvolutionEvaluator = new MockIntegerConvolutionEvaluator();
-        var realConvolutionEvaluator = new RealConvolutionEvaluator(
-            visitor,
-            variableTable,
-            compilerMessageManger
-        );
+        var realConvolutionEvaluator = new RealConvolutionEvaluator();
         var binaryOperatorEvaluator = new NumericBinaryOperatorEvaluator(
             compilerMessageManger,
             integerConvolutionEvaluator,
@@ -169,15 +144,9 @@ public class AstRealBinaryOperatorEvaluationTest
 
         var compilerMessageManger = ICompilerMessageManger.Default;
         var visitor = new MockAstBinaryOperatorVisitor();
-        var variableTable = new VariableSymbolTable();
-        variableTable.Add( MockUtility.CreateIntVariable( variableName ) );
 
         var integerConvolutionEvaluator = new MockIntegerConvolutionEvaluator();
-        var realConvolutionEvaluator = new RealConvolutionEvaluator(
-            visitor,
-            variableTable,
-            compilerMessageManger
-        );
+        var realConvolutionEvaluator = new RealConvolutionEvaluator();
         var binaryOperatorEvaluator = new NumericBinaryOperatorEvaluator(
             compilerMessageManger,
             integerConvolutionEvaluator,
@@ -204,15 +173,9 @@ public class AstRealBinaryOperatorEvaluationTest
 
         var compilerMessageManger = ICompilerMessageManger.Default;
         var visitor = new MockAstBinaryOperatorVisitor();
-        var variableTable = new VariableSymbolTable();
-        variableTable.Add( MockUtility.CreateIntVariable( variableName ) );
 
         var integerConvolutionEvaluator = new MockIntegerConvolutionEvaluator();
-        var realConvolutionEvaluator = new RealConvolutionEvaluator(
-            visitor,
-            variableTable,
-            compilerMessageManger
-        );
+        var realConvolutionEvaluator = new RealConvolutionEvaluator();
         var binaryOperatorEvaluator = new NumericBinaryOperatorEvaluator(
             compilerMessageManger,
             integerConvolutionEvaluator,
@@ -239,15 +202,9 @@ public class AstRealBinaryOperatorEvaluationTest
 
         var compilerMessageManger = ICompilerMessageManger.Default;
         var visitor = new MockAstBinaryOperatorVisitor();
-        var variableTable = new VariableSymbolTable();
-        variableTable.Add( MockUtility.CreateIntVariable( variableName ) );
 
         var integerConvolutionEvaluator = new MockIntegerConvolutionEvaluator();
-        var realConvolutionEvaluator = new RealConvolutionEvaluator(
-            visitor,
-            variableTable,
-            compilerMessageManger
-        );
+        var realConvolutionEvaluator = new RealConvolutionEvaluator();
         var binaryOperatorEvaluator = new NumericBinaryOperatorEvaluator(
             compilerMessageManger,
             integerConvolutionEvaluator,
@@ -274,15 +231,9 @@ public class AstRealBinaryOperatorEvaluationTest
 
         var compilerMessageManger = ICompilerMessageManger.Default;
         var visitor = new MockAstBinaryOperatorVisitor();
-        var variableTable = new VariableSymbolTable();
-        variableTable.Add( MockUtility.CreateIntVariable( variableName ) );
 
         var integerConvolutionEvaluator = new MockIntegerConvolutionEvaluator();
-        var realConvolutionEvaluator = new RealConvolutionEvaluator(
-            visitor,
-            variableTable,
-            compilerMessageManger
-        );
+        var realConvolutionEvaluator = new RealConvolutionEvaluator();
         var binaryOperatorEvaluator = new NumericBinaryOperatorEvaluator(
             compilerMessageManger,
             integerConvolutionEvaluator,

--- a/Compiler/Domain.Tests/Analyzer/Semantics/AstRealUnaryOperatorEvaluationTest.cs
+++ b/Compiler/Domain.Tests/Analyzer/Semantics/AstRealUnaryOperatorEvaluationTest.cs
@@ -3,7 +3,6 @@ using System;
 using KSPCompiler.Domain.Ast.Analyzers.Evaluators.Convolutions.Reals;
 using KSPCompiler.Domain.Ast.Analyzers.Semantics;
 using KSPCompiler.Domain.CompilerMessages;
-using KSPCompiler.Domain.Symbols;
 using KSPCompiler.Domain.Symbols.MetaData;
 
 using NUnit.Framework;
@@ -20,15 +19,9 @@ public class AstRealUnaryOperatorEvaluationTest
 
         var compilerMessageManger = ICompilerMessageManger.Default;
         var visitor = new MockAstUnaryOperatorVisitor();
-        var variableTable = new VariableSymbolTable();
-        variableTable.Add( MockUtility.CreateIntVariable( variableName ) );
 
         var integerConvolutionEvaluator = new MockIntegerConvolutionEvaluator();
-        var realConvolutionEvaluator = new RealConvolutionEvaluator(
-            visitor,
-            variableTable,
-            compilerMessageManger
-        );
+        var realConvolutionEvaluator = new RealConvolutionEvaluator();
         var unaryOperatorEvaluator = new NumericUnaryOperatorEvaluator(
             compilerMessageManger,
             integerConvolutionEvaluator,
@@ -53,15 +46,9 @@ public class AstRealUnaryOperatorEvaluationTest
 
         var compilerMessageManger = ICompilerMessageManger.Default;
         var visitor = new MockAstUnaryOperatorVisitor();
-        var variableTable = new VariableSymbolTable();
-        variableTable.Add( MockUtility.CreateIntVariable( variableName ) );
 
         var integerConvolutionEvaluator = new MockIntegerConvolutionEvaluator();
-        var realConvolutionEvaluator = new RealConvolutionEvaluator(
-            visitor,
-            variableTable,
-            compilerMessageManger
-        );
+        var realConvolutionEvaluator = new RealConvolutionEvaluator();
         var unaryOperatorEvaluator = new NumericUnaryOperatorEvaluator(
             compilerMessageManger,
             integerConvolutionEvaluator,

--- a/Compiler/Domain.Tests/Analyzer/Semantics/AstStringConcatenateOperatorConvolutionCalculatorTest.cs
+++ b/Compiler/Domain.Tests/Analyzer/Semantics/AstStringConcatenateOperatorConvolutionCalculatorTest.cs
@@ -4,8 +4,6 @@ using KSPCompiler.Domain.Ast.Analyzers.Evaluators.Convolutions.Strings;
 using KSPCompiler.Domain.Ast.Nodes;
 using KSPCompiler.Domain.Ast.Nodes.Expressions;
 using KSPCompiler.Domain.CompilerMessages;
-using KSPCompiler.Domain.Symbols;
-using KSPCompiler.Domain.Symbols.MetaData;
 
 using NUnit.Framework;
 
@@ -18,14 +16,13 @@ public class AstStringConcatenateOperatorConvolutionCalculatorTest
     private static void ConvolutionTestBody(
         AstExpressionNode left,
         AstExpressionNode right,
-        IVariableSymbolTable symbolTable,
         string? expectedValue,
         int expectedErrorCount )
     {
         var compilerMessageManger = ICompilerMessageManger.Default;
         var visitor = new MockDefaultAstVisitor();
 
-        var evaluator = new StringConvolutionEvaluator( visitor, symbolTable, compilerMessageManger );
+        var evaluator = new StringConvolutionEvaluator();
 
         var operatorNode = new AstStringConcatenateExpressionNode
         {
@@ -39,21 +36,6 @@ public class AstStringConcatenateOperatorConvolutionCalculatorTest
 
         Assert.AreEqual( expectedErrorCount, compilerMessageManger.Count() );
         Assert.AreEqual( expectedValue,      result );
-    }
-
-    private static void ConvolutionTestBody(
-        AstExpressionNode left,
-        AstExpressionNode right,
-        string? expectedValue,
-        int expectedErrorCount )
-    {
-        ConvolutionTestBody(
-            left,
-            right,
-            MockUtility.CreateAggregateSymbolTable().Variables,
-            expectedValue,
-            expectedErrorCount
-        );
     }
 
     #endregion
@@ -132,30 +114,6 @@ public class AstStringConcatenateOperatorConvolutionCalculatorTest
             new AstRealLiteralNode( 1.23 ),
             new AstRealLiteralNode( 4.56 ),
             "1.234.56",
-            0
-        );
-    }
-
-    [Test]
-    public void VariableAndIntConvolutionTest()
-    {
-        // declare const $x : = 123
-        // "value: " & $x
-        // -> "value: 123"
-        var variable = MockUtility.CreateStringVariable( "$x" );
-        variable.Modifier = ModifierFlag.Const;
-        variable.Value    = 123;
-
-        var symbolTable = MockUtility.CreateAggregateSymbolTable().Variables;
-        symbolTable.Add( variable );
-
-        var variableNode = MockUtility.CreateAstSymbolExpression( variable );
-
-        ConvolutionTestBody(
-            new AstStringLiteralNode( "value: " ),
-            variableNode,
-            symbolTable,
-            "value: 123",
             0
         );
     }

--- a/Compiler/Domain.Tests/Analyzer/Semantics/MockUtility.cs
+++ b/Compiler/Domain.Tests/Analyzer/Semantics/MockUtility.cs
@@ -341,7 +341,7 @@ public static class MockUtility
         var compilerMessageManger = ICompilerMessageManger.Default;
         var symbols = MockUtility.CreateAggregateSymbolTable();
 
-        var integerConvolutionEvaluator = new IntegerConvolutionEvaluator( visitor, symbols.Variables, compilerMessageManger );
+        var integerConvolutionEvaluator = new IntegerConvolutionEvaluator();
         var integerConditionalBinaryOperatorConvolutionCalculator = new IntegerConditionalBinaryOperatorConvolutionCalculator( integerConvolutionEvaluator );
 
         var realConvolutionEvaluator = new RealConvolutionEvaluator( visitor, symbols.Variables, compilerMessageManger );

--- a/Compiler/Domain.Tests/Analyzer/Semantics/MockUtility.cs
+++ b/Compiler/Domain.Tests/Analyzer/Semantics/MockUtility.cs
@@ -6,7 +6,6 @@ using KSPCompiler.Domain.Ast.Nodes;
 using KSPCompiler.Domain.Ast.Nodes.Blocks;
 using KSPCompiler.Domain.Ast.Nodes.Expressions;
 using KSPCompiler.Domain.Ast.Nodes.Statements;
-using KSPCompiler.Domain.CompilerMessages;
 using KSPCompiler.Domain.Symbols;
 using KSPCompiler.Domain.Symbols.MetaData;
 using KSPCompiler.Domain.Symbols.MetaData.Extensions;
@@ -338,13 +337,10 @@ public static class MockUtility
 
     public static IBooleanConvolutionEvaluator CreateBooleanConvolutionEvaluator( IAstVisitor visitor )
     {
-        var compilerMessageManger = ICompilerMessageManger.Default;
-        var symbols = MockUtility.CreateAggregateSymbolTable();
-
         var integerConvolutionEvaluator = new IntegerConvolutionEvaluator();
         var integerConditionalBinaryOperatorConvolutionCalculator = new IntegerConditionalBinaryOperatorConvolutionCalculator( integerConvolutionEvaluator );
 
-        var realConvolutionEvaluator = new RealConvolutionEvaluator( visitor, symbols.Variables, compilerMessageManger );
+        var realConvolutionEvaluator = new RealConvolutionEvaluator();
         var realConditionalBinaryOperatorConvolutionCalculator = new RealConditionalBinaryOperatorConvolutionCalculator( realConvolutionEvaluator );
 
         return  new BooleanConvolutionEvaluator(

--- a/Compiler/Domain/Ast/Analyzers/Evaluators/Convolutions/Integers/IntegerConstantConvolutionCalculator.cs
+++ b/Compiler/Domain/Ast/Analyzers/Evaluators/Convolutions/Integers/IntegerConstantConvolutionCalculator.cs
@@ -1,13 +1,7 @@
 using System;
 
-using KSPCompiler.Domain.Ast.Extensions;
 using KSPCompiler.Domain.Ast.Nodes;
 using KSPCompiler.Domain.Ast.Nodes.Expressions;
-using KSPCompiler.Domain.CompilerMessages;
-using KSPCompiler.Domain.Symbols;
-using KSPCompiler.Domain.Symbols.Extensions;
-using KSPCompiler.Domain.Symbols.MetaData.Extensions;
-using KSPCompiler.Resources;
 
 namespace KSPCompiler.Domain.Ast.Analyzers.Evaluators.Convolutions.Integers;
 
@@ -16,17 +10,6 @@ namespace KSPCompiler.Domain.Ast.Analyzers.Evaluators.Convolutions.Integers;
 /// </summary>
 public sealed class IntegerConstantConvolutionCalculator : IIntegerConstantConvolutionCalculator
 {
-    private IVariableSymbolTable VariableSymbols { get; }
-    private ICompilerMessageManger CompilerMessageManger { get; }
-
-    public IntegerConstantConvolutionCalculator(
-        IVariableSymbolTable variableSymbols,
-        ICompilerMessageManger compilerMessageManger )
-    {
-        VariableSymbols       = variableSymbols;
-        CompilerMessageManger = compilerMessageManger;
-    }
-
     public int? Calculate( IAstVisitor visitor, AstExpressionNode expr, int workingValueForRecursive )
     {
         if( expr.ChildNodeCount != 0 )
@@ -34,35 +17,15 @@ public sealed class IntegerConstantConvolutionCalculator : IIntegerConstantConvo
             throw new ArgumentException( $"Expected 0 child nodes, but got {expr.ChildNodeCount}. (node: {expr.GetType().Name})" );
         }
 
-        if( expr is AstIntLiteralNode literal )
+        if( expr.Accept( visitor ) is not AstExpressionNode evaluatedNode )
+        {
+            throw new AstAnalyzeException( expr, "Failed to evaluate expression" );
+        }
+
+        if( evaluatedNode is AstIntLiteralNode literal )
         {
             return literal.Value;
         }
-
-        if( VariableSymbols.TrySearchByName( expr.Name, out var variable ) )
-        {
-            if( !variable.DataType.IsInt() || !variable.Modifier.IsConstant() )
-            {
-                return null;
-            }
-
-            variable.Referenced = true;
-            variable.State      = VariableState.Loaded;
-
-            if( variable.TryGetConstantValue<int>( out var value ) )
-            {
-                return value;
-            }
-
-            // 予約変数（組み込み変数）は定数値を持たない
-            return null;
-        }
-
-        CompilerMessageManger.Error(
-            expr,
-            CompilerMessageResources.semantic_error_variable_not_declared,
-            expr.Name
-        );
 
         return null;
     }

--- a/Compiler/Domain/Ast/Analyzers/Evaluators/Convolutions/Integers/IntegerConvolutionEvaluator.cs
+++ b/Compiler/Domain/Ast/Analyzers/Evaluators/Convolutions/Integers/IntegerConvolutionEvaluator.cs
@@ -1,6 +1,4 @@
 using KSPCompiler.Domain.Ast.Nodes;
-using KSPCompiler.Domain.CompilerMessages;
-using KSPCompiler.Domain.Symbols;
 
 namespace KSPCompiler.Domain.Ast.Analyzers.Evaluators.Convolutions.Integers;
 

--- a/Compiler/Domain/Ast/Analyzers/Evaluators/Convolutions/Integers/IntegerConvolutionEvaluator.cs
+++ b/Compiler/Domain/Ast/Analyzers/Evaluators/Convolutions/Integers/IntegerConvolutionEvaluator.cs
@@ -13,11 +13,11 @@ public sealed class IntegerConvolutionEvaluator : IIntegerConvolutionEvaluator
     private IIntegerBinaryOperatorConvolutionCalculator BinaryCalculator { get; }
     private IIntegerUnaryOperatorConvolutionCalculator UnaryCalculator { get; }
 
-    public IntegerConvolutionEvaluator( IAstVisitor visitor, IVariableSymbolTable variableSymbols, ICompilerMessageManger compilerMessageManger )
+    public IntegerConvolutionEvaluator()
     {
-        ConstantCalculator   = new IntegerConstantConvolutionCalculator( variableSymbols, compilerMessageManger );
-        BinaryCalculator     = new IntegerBinaryOperatorConvolutionCalculator( this );
-        UnaryCalculator      = new IntegerUnaryOperatorConvolutionCalculator( this );
+        ConstantCalculator = new IntegerConstantConvolutionCalculator();
+        BinaryCalculator   = new IntegerBinaryOperatorConvolutionCalculator( this );
+        UnaryCalculator    = new IntegerUnaryOperatorConvolutionCalculator( this );
     }
 
     public int? Evaluate( IAstVisitor visitor, AstExpressionNode expr, int workingValueForRecursive )

--- a/Compiler/Domain/Ast/Analyzers/Evaluators/Convolutions/Reals/RealConstantConvolutionCalculator.cs
+++ b/Compiler/Domain/Ast/Analyzers/Evaluators/Convolutions/Reals/RealConstantConvolutionCalculator.cs
@@ -1,13 +1,7 @@
 using System;
 
-using KSPCompiler.Domain.Ast.Extensions;
 using KSPCompiler.Domain.Ast.Nodes;
 using KSPCompiler.Domain.Ast.Nodes.Expressions;
-using KSPCompiler.Domain.CompilerMessages;
-using KSPCompiler.Domain.Symbols;
-using KSPCompiler.Domain.Symbols.Extensions;
-using KSPCompiler.Domain.Symbols.MetaData.Extensions;
-using KSPCompiler.Resources;
 
 namespace KSPCompiler.Domain.Ast.Analyzers.Evaluators.Convolutions.Reals;
 
@@ -16,17 +10,6 @@ namespace KSPCompiler.Domain.Ast.Analyzers.Evaluators.Convolutions.Reals;
 /// </summary>
 public sealed class RealConstantConvolutionCalculator : IRealConstantConvolutionCalculator
 {
-    private IVariableSymbolTable VariableSymbols { get; }
-    private ICompilerMessageManger CompilerMessageManger { get; }
-
-    public RealConstantConvolutionCalculator(
-        IVariableSymbolTable variableSymbols,
-        ICompilerMessageManger compilerMessageManger )
-    {
-        VariableSymbols       = variableSymbols;
-        CompilerMessageManger = compilerMessageManger;
-    }
-
     public double? Calculate( IAstVisitor visitor, AstExpressionNode expr, double _ )
     {
         if( expr.ChildNodeCount != 0 )
@@ -34,40 +17,15 @@ public sealed class RealConstantConvolutionCalculator : IRealConstantConvolution
             throw new ArgumentException( $"Expected 0 child nodes, but got {expr.ChildNodeCount}. (node: {expr.GetType().Name})" );
         }
 
-        if( expr is AstRealLiteralNode literal )
+        if( expr.Accept( visitor ) is not AstExpressionNode evaluatedNode )
+        {
+            throw new AstAnalyzeException( expr, "Failed to evaluate expression" );
+        }
+
+        if( evaluatedNode is AstRealLiteralNode literal )
         {
             return literal.Value;
         }
-
-        if( expr is not AstExpressionNode symbol )
-        {
-            return null;
-        }
-
-        if( VariableSymbols.TrySearchByName( symbol.Name, out var variable ) )
-        {
-            if( !variable.DataType.IsReal() || !variable.Modifier.IsConstant() )
-            {
-                return null;
-            }
-
-            variable.Referenced = true;
-            variable.State      = VariableState.Loaded;
-
-            if( variable.TryGetConstantValue<double>( out var value ) )
-            {
-                return value;
-            }
-
-            // 予約変数（組み込み変数）は定数値を持たない
-            return null;
-        }
-
-        CompilerMessageManger.Error(
-            expr,
-            CompilerMessageResources.semantic_error_variable_not_declared,
-            symbol.Name
-        );
 
         return null;
     }

--- a/Compiler/Domain/Ast/Analyzers/Evaluators/Convolutions/Reals/RealConvolutionEvaluator.cs
+++ b/Compiler/Domain/Ast/Analyzers/Evaluators/Convolutions/Reals/RealConvolutionEvaluator.cs
@@ -1,6 +1,4 @@
 using KSPCompiler.Domain.Ast.Nodes;
-using KSPCompiler.Domain.CompilerMessages;
-using KSPCompiler.Domain.Symbols;
 
 namespace KSPCompiler.Domain.Ast.Analyzers.Evaluators.Convolutions.Reals;
 
@@ -13,11 +11,11 @@ public sealed class RealConvolutionEvaluator : IRealConvolutionEvaluator
     private IRealBinaryOperatorConvolutionCalculator BinaryCalculator { get; }
     private IRealUnaryOperatorConvolutionCalculator UnaryCalculator { get; }
 
-    public RealConvolutionEvaluator( IAstVisitor visitor, IVariableSymbolTable variableSymbols, ICompilerMessageManger compilerMessageManger )
+    public RealConvolutionEvaluator()
     {
-        ConstantCalculator   = new RealConstantConvolutionCalculator( variableSymbols, compilerMessageManger );
-        BinaryCalculator     = new RealBinaryOperatorConvolutionCalculator( this );
-        UnaryCalculator      = new RealUnaryOperatorConvolutionCalculator( this );
+        ConstantCalculator = new RealConstantConvolutionCalculator();
+        BinaryCalculator   = new RealBinaryOperatorConvolutionCalculator( this );
+        UnaryCalculator    = new RealUnaryOperatorConvolutionCalculator( this );
     }
 
     public double? Evaluate( IAstVisitor visitor, AstExpressionNode expr, double workingValueForRecursive )

--- a/Compiler/Domain/Ast/Analyzers/Evaluators/Convolutions/Strings/StringConstantConvolutionCalculator.cs
+++ b/Compiler/Domain/Ast/Analyzers/Evaluators/Convolutions/Strings/StringConstantConvolutionCalculator.cs
@@ -1,14 +1,8 @@
 using System;
 using System.Globalization;
 
-using KSPCompiler.Domain.Ast.Extensions;
 using KSPCompiler.Domain.Ast.Nodes;
 using KSPCompiler.Domain.Ast.Nodes.Expressions;
-using KSPCompiler.Domain.CompilerMessages;
-using KSPCompiler.Domain.Symbols;
-using KSPCompiler.Domain.Symbols.Extensions;
-using KSPCompiler.Domain.Symbols.MetaData.Extensions;
-using KSPCompiler.Resources;
 
 namespace KSPCompiler.Domain.Ast.Analyzers.Evaluators.Convolutions.Strings;
 
@@ -17,16 +11,6 @@ namespace KSPCompiler.Domain.Ast.Analyzers.Evaluators.Convolutions.Strings;
 /// </summary>
 public sealed class StringConstantConvolutionCalculator : IStringConstantConvolutionCalculator
 {
-    private IVariableSymbolTable VariableSymbols { get; }
-    private ICompilerMessageManger CompilerMessageManger { get; }
-
-    public StringConstantConvolutionCalculator(
-        IVariableSymbolTable variableSymbols,
-        ICompilerMessageManger compilerMessageManger )
-    {
-        VariableSymbols       = variableSymbols;
-        CompilerMessageManger = compilerMessageManger;
-    }
     public string? Calculate( IAstVisitor visitor, AstExpressionNode expr, string _ )
     {
         if( expr.ChildNodeCount != 0 )
@@ -34,75 +18,17 @@ public sealed class StringConstantConvolutionCalculator : IStringConstantConvolu
             throw new ArgumentException( $"Expected 0 child nodes, but got {expr.ChildNodeCount}. (node: {expr.GetType().Name})" );
         }
 
-        if( TryGetLiteralValue( expr, out var literalValue ) )
+        if( expr.Accept( visitor ) is not AstExpressionNode evaluatedNode )
         {
-            return literalValue;
+            throw new AstAnalyzeException( expr, "Failed to evaluate expression" );
         }
 
-        if( TryGetConstantVariable( expr, out var result ) )
+        return evaluatedNode switch
         {
-            return result;
-        }
-
-        return null;
-    }
-
-    private static bool TryGetLiteralValue( AstExpressionNode expr, out string? result )
-    {
-        switch( expr )
-        {
-            case AstStringLiteralNode literal:
-                result = literal.Value;
-                return true;
-            case AstIntLiteralNode intLiteral:
-                result = intLiteral.Value.ToString();
-                return true;
-            case AstRealLiteralNode realLiteral:
-                result = realLiteral.Value.ToString( CultureInfo.InvariantCulture );
-                return true;
-            default:
-                result = null;
-                return false;
-        }
-    }
-
-    private bool TryGetConstantVariable( AstExpressionNode symbol, out string? result )
-    {
-
-        if( !VariableSymbols.TrySearchByName( symbol.Name, out var variable ) )
-        {
-            result = null;
-            return false;
-        }
-
-        if( !variable.Modifier.IsConstant() )
-        {
-            result = null;
-            return false;
-        }
-
-        variable.Referenced = true;
-        variable.State      = VariableState.Loaded;
-
-        if( variable.TryGetConstantValue<string>( out var value ) )
-        {
-            result = value;
-            return true;
-        }
-        else if( variable.TryGetConstantValue<int>( out var intValue ) )
-        {
-            result = intValue.ToString();
-            return true;
-        }
-        else if( variable.TryGetConstantValue<double>( out var realValue ) )
-        {
-            result = realValue.ToString( CultureInfo.InvariantCulture );
-            return true;
-        }
-
-        // 予約変数（組み込み変数）は定数値を持たない
-        result = null;
-        return false;
-
+            AstStringLiteralNode literal   => literal.Value,
+            AstIntLiteralNode intLiteral   => intLiteral.Value.ToString(),
+            AstRealLiteralNode realLiteral => realLiteral.Value.ToString( CultureInfo.InvariantCulture ),
+            _                              => null
+        };
     }
 }

--- a/Compiler/Domain/Ast/Analyzers/Evaluators/Convolutions/Strings/StringConvolutionEvaluator.cs
+++ b/Compiler/Domain/Ast/Analyzers/Evaluators/Convolutions/Strings/StringConvolutionEvaluator.cs
@@ -1,6 +1,4 @@
 using KSPCompiler.Domain.Ast.Nodes;
-using KSPCompiler.Domain.CompilerMessages;
-using KSPCompiler.Domain.Symbols;
 
 namespace KSPCompiler.Domain.Ast.Analyzers.Evaluators.Convolutions.Strings;
 
@@ -12,9 +10,9 @@ public sealed class StringConvolutionEvaluator : IStringConvolutionEvaluator
     private IStringConstantConvolutionCalculator ConstantCalculator { get; }
     private IStringConcatenateOperatorConvolutionCalculator ConcatenateCalculator { get; }
 
-    public StringConvolutionEvaluator( IAstVisitor visitor, IVariableSymbolTable variableSymbols, ICompilerMessageManger compilerMessageManger )
+    public StringConvolutionEvaluator()
     {
-        ConstantCalculator    = new StringConstantConvolutionCalculator( variableSymbols, compilerMessageManger );
+        ConstantCalculator    = new StringConstantConvolutionCalculator();
         ConcatenateCalculator = new StringConcatenateOperatorConvolutionCalculator( this );
     }
 

--- a/Compiler/Domain/Ast/Analyzers/Semantics/SemanticAnalyzer.cs
+++ b/Compiler/Domain/Ast/Analyzers/Semantics/SemanticAnalyzer.cs
@@ -64,7 +64,7 @@ public partial class SemanticAnalyzer : DefaultAstVisitor, IAstTraversal
         UserFunctionDeclarationEvaluator = new UserFunctionDeclarationEvaluator( CompilerMessageManger, SymbolTable.UserFunctions );
         VariableDeclarationEvaluator     = new VariableDeclarationEvaluator( CompilerMessageManger, SymbolTable.Variables, SymbolTable.UITypes );
 
-        IntegerConvolutionEvaluator = new IntegerConvolutionEvaluator( this, SymbolTable.Variables, CompilerMessageManger );
+        IntegerConvolutionEvaluator = new IntegerConvolutionEvaluator();
         RealConvolutionEvaluator    = new RealConvolutionEvaluator( this, SymbolTable.Variables, CompilerMessageManger );
         //StringConvolutionEvaluator  = new StringConvolutionEvaluator( this, SymbolTable.Variables, CompilerMessageManger );
 

--- a/Compiler/Domain/Ast/Analyzers/Semantics/SemanticAnalyzer.cs
+++ b/Compiler/Domain/Ast/Analyzers/Semantics/SemanticAnalyzer.cs
@@ -65,7 +65,7 @@ public partial class SemanticAnalyzer : DefaultAstVisitor, IAstTraversal
         VariableDeclarationEvaluator     = new VariableDeclarationEvaluator( CompilerMessageManger, SymbolTable.Variables, SymbolTable.UITypes );
 
         IntegerConvolutionEvaluator = new IntegerConvolutionEvaluator();
-        RealConvolutionEvaluator    = new RealConvolutionEvaluator( this, SymbolTable.Variables, CompilerMessageManger );
+        RealConvolutionEvaluator    = new RealConvolutionEvaluator();
         //StringConvolutionEvaluator  = new StringConvolutionEvaluator( this, SymbolTable.Variables, CompilerMessageManger );
 
         NumericBinaryOperatorEvaluator     = new NumericBinaryOperatorEvaluator( CompilerMessageManger, IntegerConvolutionEvaluator, RealConvolutionEvaluator );

--- a/Compiler/Domain/Ast/Analyzers/Semantics/SemanticAnalyzer.cs
+++ b/Compiler/Domain/Ast/Analyzers/Semantics/SemanticAnalyzer.cs
@@ -66,7 +66,7 @@ public partial class SemanticAnalyzer : DefaultAstVisitor, IAstTraversal
 
         IntegerConvolutionEvaluator = new IntegerConvolutionEvaluator( this, SymbolTable.Variables, CompilerMessageManger );
         RealConvolutionEvaluator    = new RealConvolutionEvaluator( this, SymbolTable.Variables, CompilerMessageManger );
-        StringConvolutionEvaluator  = new StringConvolutionEvaluator( this, SymbolTable.Variables, CompilerMessageManger );
+        //StringConvolutionEvaluator  = new StringConvolutionEvaluator( this, SymbolTable.Variables, CompilerMessageManger );
 
         NumericBinaryOperatorEvaluator     = new NumericBinaryOperatorEvaluator( CompilerMessageManger, IntegerConvolutionEvaluator, RealConvolutionEvaluator );
         NumericUnaryOperatorEvaluator      = new NumericUnaryOperatorEvaluator( CompilerMessageManger, IntegerConvolutionEvaluator, RealConvolutionEvaluator );


### PR DESCRIPTION
Modified convolution to obtain node evaluation results without direct reference to the variable table.

畳み込みで変数テーブルを直接参照せずにノード評価の結果を得るように修正した。