### PR TITLE
Fix Type Propagation Through Binary Expressions

### DIFF
--- a/Compiler/Features/Compilation/UseCase.Tests/Analysis/Semantics/AstCallCommandEvaluationTest.cs
+++ b/Compiler/Features/Compilation/UseCase.Tests/Analysis/Semantics/AstCallCommandEvaluationTest.cs
@@ -3,10 +3,14 @@ using System;
 using KSPCompiler.Features.Compilation.Domain.Messages;
 using KSPCompiler.Features.Compilation.Domain.Messages.Extensions;
 using KSPCompiler.Features.Compilation.Gateways.EventEmitting;
+using KSPCompiler.Features.Compilation.UseCase.Analysis.Commons.Evaluations.Convolutions.Integers;
+using KSPCompiler.Features.Compilation.UseCase.Analysis.Commons.Evaluations.Convolutions.Reals;
 using KSPCompiler.Features.Compilation.UseCase.Analysis.Semantics;
 using KSPCompiler.Features.SymbolManagement.UseCase.Tests.Commons;
+using KSPCompiler.Shared.Domain.Compilation.Ast.Nodes;
 using KSPCompiler.Shared.Domain.Compilation.Ast.Nodes.Expressions;
 using KSPCompiler.Shared.Domain.Compilation.Symbols;
+using KSPCompiler.Shared.Domain.Compilation.Symbols.MetaData;
 using KSPCompiler.Shared.EventEmitting.Extensions;
 
 using NUnit.Framework;
@@ -243,5 +247,62 @@ public class AstCallCommandEvaluationTest
         compilerMessageManger.WriteTo( Console.Out );
 
         Assert.That( compilerMessageManger.Count( CompilerMessageLevel.Warning ), Is.EqualTo( 1 ) );
+    }
+
+    [Test]
+    public void CallCommandWithBinaryExpressionArgTest()
+    {
+        var compilerMessageManger = ICompilerMessageManger.Default;
+        var eventEmitter = new MockEventEmitter();
+        eventEmitter.Subscribe<CompilationErrorEvent>( e => compilerMessageManger.Error( e.Position, e.Message ) );
+
+        var symbols = new AggregateSymbolTable();
+
+        // register command `int_to_real`
+        // int_to_real(<integer>) -> real
+        var command = MockUtility.CreateCommand(
+            "int_to_real",
+            DataTypeFlag.TypeReal,
+            new CommandArgumentSymbol
+            {
+                Name     = "integer",
+                DataType = DataTypeFlag.TypeInt
+            }
+        );
+
+        symbols.Commands.AddAsOverload( command, command.Arguments );
+
+        // Create a call command expression node with a binary expression argument
+        // int_to_real( 10 - 5 )
+        var binaryExpr = new AstSubtractionExpressionNode
+        {
+            Left  = new AstIntLiteralNode( 10 ),
+            Right = new AstIntLiteralNode( 5 )
+        };
+
+        var callCommandAst = MockUtility.CreateCommandExpressionNode(
+            "int_to_real",
+            binaryExpr
+        );
+
+        var callCommandEvaluator = new CallCommandEvaluator( eventEmitter, symbols );
+        var binaryOperatorEvaluator = new NumericBinaryOperatorEvaluator(
+            eventEmitter,
+            symbols,
+            new MockIntegerConvolutionEvaluator( null ),
+            new RealConvolutionEvaluator()
+        );
+
+        var visitor = new MockCallCommandExpressionVisitor();
+        visitor.Inject( callCommandEvaluator );
+        visitor.Inject( binaryOperatorEvaluator );
+
+        var result = callCommandEvaluator.Evaluate( visitor, callCommandAst ) as AstExpressionNode;
+
+        compilerMessageManger.WriteTo( Console.Out );
+
+        Assert.That( compilerMessageManger.Count( CompilerMessageLevel.Error ), Is.EqualTo( 0 ) );
+        Assert.That( result, Is.Not.Null );
+        Assert.That( result?.TypeFlag, Is.EqualTo( DataTypeFlag.TypeReal ) );
     }
 }

--- a/Compiler/Features/Compilation/UseCase.Tests/Analysis/Semantics/MockCallCommandExpressionVisitor.cs
+++ b/Compiler/Features/Compilation/UseCase.Tests/Analysis/Semantics/MockCallCommandExpressionVisitor.cs
@@ -1,4 +1,5 @@
 using KSPCompiler.Features.Compilation.UseCase.Analysis.Abstractions.Evaluations.Commands;
+using KSPCompiler.Features.Compilation.UseCase.Analysis.Abstractions.Evaluations.Operators;
 using KSPCompiler.Shared.Domain.Compilation.Ast.Nodes;
 using KSPCompiler.Shared.Domain.Compilation.Ast.Nodes.Expressions;
 
@@ -7,12 +8,42 @@ namespace KSPCompiler.Features.SymbolManagement.UseCase.Tests.Analysis.Semantics
 public class MockCallCommandExpressionVisitor : DefaultAstVisitor
 {
     private ICallCommandEvaluator CallCommandEvaluator { get; set; } = new MockICallCommandEvaluator();
+    private IBinaryOperatorEvaluator? NumericBinaryOperatorEvaluator { get; set; }
 
     public void Inject( ICallCommandEvaluator iCallCommandEvaluator )
     {
         CallCommandEvaluator = iCallCommandEvaluator;
     }
 
+    public void Inject( IBinaryOperatorEvaluator binaryOperatorEvaluator )
+    {
+        NumericBinaryOperatorEvaluator = binaryOperatorEvaluator;
+    }
+
     public override IAstNode Visit( AstCallCommandExpressionNode node )
         => CallCommandEvaluator.Evaluate( this, node );
+
+    public override IAstNode Visit( AstAdditionExpressionNode node )
+        => NumericBinaryOperatorEvaluator?.Evaluate( this, node ) ?? base.Visit( node );
+
+    public override IAstNode Visit( AstSubtractionExpressionNode node )
+        => NumericBinaryOperatorEvaluator?.Evaluate( this, node ) ?? base.Visit( node );
+
+    public override IAstNode Visit( AstMultiplyingExpressionNode node )
+        => NumericBinaryOperatorEvaluator?.Evaluate( this, node ) ?? base.Visit( node );
+
+    public override IAstNode Visit( AstDivisionExpressionNode node )
+        => NumericBinaryOperatorEvaluator?.Evaluate( this, node ) ?? base.Visit( node );
+
+    public override IAstNode Visit( AstModuloExpressionNode node )
+        => NumericBinaryOperatorEvaluator?.Evaluate( this, node ) ?? base.Visit( node );
+
+    public override IAstNode Visit( AstBitwiseOrExpressionNode node )
+        => NumericBinaryOperatorEvaluator?.Evaluate( this, node ) ?? base.Visit( node );
+
+    public override IAstNode Visit( AstBitwiseAndExpressionNode node )
+        => NumericBinaryOperatorEvaluator?.Evaluate( this, node ) ?? base.Visit( node );
+
+    public override IAstNode Visit( AstBitwiseXorExpressionNode node )
+        => NumericBinaryOperatorEvaluator?.Evaluate( this, node ) ?? base.Visit( node );
 }

--- a/Compiler/Features/Compilation/UseCase/Analysis/Semantics/CallCommandEvaluator.cs
+++ b/Compiler/Features/Compilation/UseCase/Analysis/Semantics/CallCommandEvaluator.cs
@@ -88,6 +88,19 @@ public class CallCommandEvaluator : ICallCommandEvaluator
             callArgs.AddRange( arguments.Expressions );
         }
 
+        // 引数の式を事前に評価し、型情報を取得する
+        var evaluatedCallArgs = new List<AstExpressionNode>();
+
+        foreach( var callArg in callArgs )
+        {
+            if( callArg.Accept( visitor ) is not AstExpressionNode evaluatedArg )
+            {
+                throw new AstAnalyzeException( callArg, "Failed to evaluate command argument" );
+            }
+
+            evaluatedCallArgs.Add( evaluatedArg );
+        }
+
         foreach( var x in commandSymbols )
         {
             var symbolArgs = x.Arguments.ToList();
@@ -104,12 +117,12 @@ public class CallCommandEvaluator : ICallCommandEvaluator
 
             #region With arguments command calling
             // 引数オーバーロード毎の引数の数が一致しない時点で評価はここまで
-            if( symbolArgs.Count != callArgs.Count )
+            if( symbolArgs.Count != evaluatedCallArgs.Count )
             {
                 continue;
             }
 
-            if( ValidateCommandArgumentType( visitor, expr, x, callArgs, symbolArgs ) )
+            if( ValidateCommandArgumentType( expr, x, evaluatedCallArgs, symbolArgs ) )
             {
                 return true;
             }
@@ -123,28 +136,19 @@ public class CallCommandEvaluator : ICallCommandEvaluator
                 CompilerMessageResources.semantic_error_command_arg_incompatible,
                 commandName,
                 commandSymbols.ToIncompatibleMessage(),
-                callArgs.ToIncompatibleMessage( commandName )
+                evaluatedCallArgs.ToIncompatibleMessage( commandName )
             )
         );
 
         return false;
     }
 
-    private bool ValidateCommandArgumentType( IAstVisitor visitor, AstCallCommandExpressionNode expr, CommandSymbol commandSymbol, IReadOnlyList<AstExpressionNode> callArgs, IReadOnlyList<CommandArgumentSymbol> symbolArgs )
+    private bool ValidateCommandArgumentType( AstCallCommandExpressionNode expr, CommandSymbol commandSymbol, IReadOnlyList<AstExpressionNode> evaluatedCallArgs, IReadOnlyList<CommandArgumentSymbol> symbolArgs )
     {
-        var evaluatedArgs = new List<AstExpressionNode>();
-
-        for( var i = 0; i < callArgs.Count; i++ )
+        for( var i = 0; i < evaluatedCallArgs.Count; i++ )
         {
             var symbolArg = symbolArgs[ i ];
-            var callArg = callArgs[ i ];
-
-            if( callArg.Accept( visitor ) is not AstExpressionNode evaluatedArg )
-            {
-                throw new AstAnalyzeException( callArg, "Failed to evaluate command argument" );
-            }
-
-            evaluatedArgs.Add( evaluatedArg );
+            var evaluatedArg = evaluatedCallArgs[ i ];
 
             // プリミティブ型の型評価
             if( TypeCompatibility.IsTypeCompatible( evaluatedArg.TypeFlag, symbolArg.DataType ) )
@@ -196,7 +200,7 @@ public class CallCommandEvaluator : ICallCommandEvaluator
         }
 
         // 引数が畳み込みでリテラルになっていれば引数の式を置き換える
-        ReplaceConvolutedCommandArguments( expr, evaluatedArgs );
+        ReplaceConvolutedCommandArguments( expr, evaluatedCallArgs );
 
         return true;
     }

--- a/Data/Symbols/commands.yaml
+++ b/Data/Symbols/commands.yaml
@@ -1863,7 +1863,7 @@ Data:
   Description: |-
     Converts a real number into an integer.
   BuiltIntoVersion: N/A
-  ReturnType: I||S
+  ReturnType: I
   Arguments:
   - Name: real
     DataType: R
@@ -1875,14 +1875,14 @@ Data:
   Name: int_to_real
   BuiltIn: true
   Description: |-
-    Converts a real number into an integer.
+    Converts an integer value into a real number.
   BuiltIntoVersion: N/A
-  ReturnType: I||S
+  ReturnType: R
   Arguments:
-  - Name: real
-    DataType: R
+  - Name: integer
+    DataType: I
     Description: |-
-      A real value to convert.
+      An integer value to convert.
   CreatedAt: 2025-03-29T06:15:22.6928030Z
   UpdatedAt: 2025-03-29T06:15:22.6928030Z
 - Id: af4e892f-1b46-4eb7-b9b7-63f9a7ae8de4
@@ -3056,11 +3056,11 @@ Data:
   Name: real
   BuiltIn: true
   Description: |-
-    Converts an integer value into a real numberConverts a real number into an integer.
+    Converts an integer value into a real number.
   BuiltIntoVersion: N/A
-  ReturnType: I||S
+  ReturnType: R
   Arguments:
-  - Name: real
+  - Name: integer
     DataType: I
     Description: |-
       An integer value to convert.
@@ -3070,14 +3070,14 @@ Data:
   Name: real_to_int
   BuiltIn: true
   Description: |-
-    Converts an integer value into a real numberConverts a real number into an integer.
+    Converts a real number into an integer.
   BuiltIntoVersion: N/A
-  ReturnType: I||S
+  ReturnType: I
   Arguments:
   - Name: real
-    DataType: I
+    DataType: R
     Description: |-
-      An integer value to convert.
+      A real value to convert.
   CreatedAt: 2025-03-29T06:15:22.6928250Z
   UpdatedAt: 2025-03-29T06:15:22.6928250Z
 - Id: 29c1c288-68ca-40fc-bc0c-3f0a99f17163

--- a/Data/Symbols/commands.yaml
+++ b/Data/Symbols/commands.yaml
@@ -1863,7 +1863,7 @@ Data:
   Description: |-
     Converts a real number into an integer.
   BuiltIntoVersion: N/A
-  ReturnType: I
+  ReturnType: I||S
   Arguments:
   - Name: real
     DataType: R
@@ -1877,7 +1877,7 @@ Data:
   Description: |-
     Converts an integer value into a real number.
   BuiltIntoVersion: N/A
-  ReturnType: R
+  ReturnType: R||S
   Arguments:
   - Name: integer
     DataType: I
@@ -3072,7 +3072,7 @@ Data:
   Description: |-
     Converts a real number into an integer.
   BuiltIntoVersion: N/A
-  ReturnType: I
+  ReturnType: I||S
   Arguments:
   - Name: real
     DataType: R


### PR DESCRIPTION
Fix Type Propagation Through Binary Expressions

## Issue Summary

When arithmetic sub-expressions are passed as arguments to `int_to_real()` or `real_to_int()`, the compiler's type evaluator returns `unknown` instead of correctly inferring the result type. This causes cascading false-positive errors on assignments and mixed-type expressions.

**Failing pattern:**
```ksp
~norm := int_to_real($vib_speed - $VIB_BP_10PCT) / int_to_real($VIB_BP_50PCT - $VIB_BP_10PCT)
$val  := 500000 + real_to_int(int_to_real($depth) * 135715.0 / 1000000.0)
```

**Error:** `int_to_real: Command argument(s) are not compatible type(s) - expected: int_to_real(real), actual: int_to_real(unknown)`